### PR TITLE
Update README_MACOS.md

### DIFF
--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -112,6 +112,10 @@ E: [] socket-server.c: bind(): Address already in use
 E: [] module.c: Failed to load module "module-esound-protocol-unix" (argument: ""): initialization failed.
 ```
 
+Make sure that PulseAudio has Microphone permissions on System Settings > Privacy & Security.
+
+PulseAudio may use a different audio output (sink) than the one actually used by the macOS system, so make sure that the current sink is the same than the current system audio output. Run the command ``pactl info`` into your macOS machine and compare the **Default sink** with the Description of ``pactl list sinks`` command. You can change the current PulseAudio output with the command ``pactl set-default-sink "<sink-name>"``.
+
 ## How to use these images
 
 Please refer to [this section](README.md#how-to-use-these-images) of the documentation.


### PR DESCRIPTION
Improve troubleshooting steps to include Privacy Settings and also instructs the user to check the current PulseAudio sink to make sure it matches the current macOS system audio output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated macOS instructions to include guidance on granting microphone permissions to PulseAudio.
  - Added steps for checking and changing the PulseAudio audio output sink to match the system default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->