### PR TITLE
Add additional troubleshooting step for macOS

### DIFF
--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -72,6 +72,12 @@ Make sure the service is running properly as a daemon.
 pulseaudio --check -v
 ```
 
+Make sure that the module `module-native-protocol-tcp` is loaded:
+
+```bash
+pactl list modules | grep module-native-protocol-tcp
+```
+
 If eveything is up and running, then the `pactl info` command should return basic information about PulseAudio such as the default `sink` and `source`.
 
 The ultime test will be to run a Docker container and waiting for the sounds the be played.


### PR DESCRIPTION
List modules to make sure that pactl list modules | grep module-native-protocol-tcp is loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions to include a step for verifying that the PulseAudio TCP module is loaded, helping users ensure proper configuration for network audio streaming on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->