### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 
 [![Open Voice OS logo](https://raw.githubusercontent.com/OpenVoiceOS/ovos-docker/dev/docs/assets/logo.png)](https://openvoiceos.org/)
 
+This repo holds the Dockerfiles and Buildx Bake configuration for the container images of [Open Voice OS](https://openvoiceos.org/), an open-source voice assistant platform. The images cover the core runtime, its services, GUIs, and default skills. Docker Buildx Bake builds and publishes the images.
+
 ## Documentation
 
-Please follow the dedicated [documentation](https://openvoiceos.github.io/ovos-docker/).
+Follow the dedicated [documentation](https://openvoiceos.github.io/ovos-docker/) for compose files, audio setup, GUI setup, and device mapping.
 
 ## What this repo builds
 
@@ -23,18 +25,20 @@ Please follow the dedicated [documentation](https://openvoiceos.github.io/ovos-d
 
 ## Run images
 
-These images run on Docker or Podman. For compose files, audio/GUI setup, and device
-mapping examples, follow the documentation.
+These images run on Docker or Podman.
 
 - Docker: `docker pull docker.io/smartgic/ovos-core:alpha`
 - Podman: `podman pull docker.io/smartgic/ovos-core:alpha`
+
+For compose files, audio/GUI setup, and device mapping examples, follow the
+documentation.
 
 ## Build requirements
 
 - Docker with Buildx (BuildKit) available for builds
 - Podman works for running images, but builds use Docker Buildx Bake
 - Network access to pull base images and dependencies
-- Multi-arch builds may require binfmt/qemu; `scripts/bake.sh` can install it via
+- Multi-arch builds may need binfmt/qemu. `scripts/bake.sh` can install it with
   `tonistiigi/binfmt` (set `ENSURE_BINFMT=true` or use `--ensure-binfmt`)
 
 ## Build images
@@ -96,8 +100,18 @@ manifest lists (see `.github/workflows/`):
 from (digest, ovos-releases commit, installed packages). Every image carries the label
 `io.openvoiceos.constraints.ref` with the ovos-releases commit its constraints came from.
 
+## Related projects
+
+- [OpenVoiceOS/ovos-core](https://github.com/OpenVoiceOS/ovos-core): the core runtime this repo packages
+- [OpenVoiceOS/ovos-docker-stt](https://github.com/OpenVoiceOS/ovos-docker-stt): speech-to-text container images
+- [OpenVoiceOS/ovos-docker-tts](https://github.com/OpenVoiceOS/ovos-docker-tts): text-to-speech container images
+
 ## Support
 
 - [Matrix channel](https://matrix.to/#/#openvoiceos:matrix.org)
 - [Contribute to Open Voice OS](https://openvoiceos.github.io/community-docs/contributing/)
 - [Report bugs related to these Docker images](https://github.com/OpenVoiceOS/ovos-docker/issues)
+
+## License
+
+This repo is under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -10,108 +10,136 @@
 
 [![Open Voice OS logo](https://raw.githubusercontent.com/OpenVoiceOS/ovos-docker/dev/docs/assets/logo.png)](https://openvoiceos.org/)
 
-This repo holds the Dockerfiles and Buildx Bake configuration for the container images of [Open Voice OS](https://openvoiceos.org/), an open-source voice assistant platform. The images cover the core runtime, its services, GUIs, and default skills. Docker Buildx Bake builds and publishes the images.
+This repository holds the Dockerfiles, the Docker Buildx Bake configuration, and the
+compose files for the container images of [Open Voice OS](https://openvoiceos.org/), an
+open-source voice assistant platform. The images cover the core runtime, its services, and
+the default skills. GitHub Actions builds the images for `amd64` and `arm64` and publishes
+them to Docker Hub and to a GHCR mirror.
 
 ## Documentation
 
-Follow the dedicated [documentation](https://openvoiceos.github.io/ovos-docker/) for compose files, audio setup, GUI setup, and device mapping.
+Read the [documentation](https://openvoiceos.github.io/ovos-docker/) for the compose files,
+the audio setup, and the device mapping.
 
-## What this repo builds
+## What this repository builds
 
-- Base layers: `ovos-base`, `ovos-sound-base`
+- Base layers: `ovos-base`, `ovos-sound-base`, `ovos-skill-base`
 - Core runtime: `ovos-core`
-- Services: `ovos-audio`, `ovos-cli`, `ovos-listener`, `ovos-messagebus`, `ovos-phal`, `ovos-phal-admin`, `ovos-plugin-ggwave`, `ovos-gui-websocket`
-- Skills: `ovos-skill-base` plus the default skill images in `docker-bake.hcl`
+- Services: `ovos-audio`, `ovos-cli`, `ovos-listener`, `ovos-messagebus`, `ovos-phal`,
+  `ovos-phal-admin`, `ovos-plugin-ggwave`, `ovos-gui-websocket`
+- Skills: one image per entry of the `SKILLS` list in `docker-bake.hcl`
+
+All Python images share `ovos-base` (Debian slim, Python 3.13, a virtual environment, and a
+pinned [uv](https://github.com/astral-sh/uv)). Each image has a `HEALTHCHECK`, an SBOM, a
+provenance attestation, and a cosign signature.
 
 ## Run images
 
-These images run on Docker or Podman.
+The images run on Docker or on Podman.
 
 - Docker: `docker pull docker.io/smartgic/ovos-core:alpha`
 - Podman: `podman pull docker.io/smartgic/ovos-core:alpha`
 
-For compose files, audio/GUI setup, and device mapping examples, follow the
-documentation.
+The same images, with the same tags and digests, are available from the mirror
+`ghcr.io/openvoiceos`. Use the mirror if Docker Hub limits your pulls.
+
+### Tags
+
+| Tag | Content |
+|---|---|
+| `alpha` | Built from `constraints-alpha.txt` of [ovos-releases](https://github.com/OpenVoiceOS/ovos-releases): alpha releases from PyPI |
+| `testing` | Built from `constraints-testing.txt`: stable versions selected for testing |
+| `stable` | Built from `constraints-stable.txt` |
+| `latest` | The same image as `stable` |
+| `<channel>-YYYYMMDD` | An immutable copy of a channel tag, for rollbacks |
+
+For the compose files, the audio setup, and the device mapping, read the documentation.
 
 ## Build requirements
 
-- Docker with Buildx (BuildKit) available for builds
-- Podman works for running images, but builds use Docker Buildx Bake
-- Network access to pull base images and dependencies
-- Multi-arch builds may need binfmt/qemu. `scripts/bake.sh` can install it with
-  `tonistiigi/binfmt` (set `ENSURE_BINFMT=true` or use `--ensure-binfmt`)
+- Docker with Buildx (BuildKit). Podman runs the images, but the builds use Docker Buildx Bake.
+- Network access, to pull the base images and the dependencies.
+- For multi-arch builds, binfmt/qemu. `scripts/bake.sh` can install it with
+  `tonistiigi/binfmt` (set `ENSURE_BINFMT=true`, or use `--ensure-binfmt`).
 
 ## Build images
 
-Builds are handled via Docker Buildx Bake (`docker-bake.hcl` and `scripts/bake.sh`).
-Direct `docker build` usage is not supported because base image wiring relies on
-Bake contexts.
+Docker Buildx Bake builds the images (`docker-bake.hcl` and `scripts/bake.sh`). Do not use
+`docker build` directly: the base image wiring relies on Bake contexts.
 
 ### Quick examples
 
-- Local build (amd64 only, loads to local Docker): `./scripts/bake.sh --load --no-push`
-- Multi-arch publish (default registry/tag): `./scripts/bake.sh`
+- Local build (amd64 only, loaded into Docker): `./scripts/bake.sh --load --no-push`
+- Multi-arch publish (default registry and tag): `./scripts/bake.sh`
 - Multi-arch alpha publish: `TAG=alpha CHANNEL=alpha VERSION=alpha PLATFORMS=linux/amd64,linux/arm64 ./scripts/bake.sh`
-- Build a subset: `./scripts/bake.sh -T stack` or `./scripts/bake.sh -T skills`
-- Disable registry cache: `./scripts/bake.sh --no-cache-from --load --no-push`
-- Note: `--load` forces `linux/amd64` because Docker cannot load multi-arch manifests locally.
+- Build a subset: `./scripts/bake.sh -T stack`, or `./scripts/bake.sh -T skills`
+- Disable the registry cache: `./scripts/bake.sh --no-cache-from --load --no-push`
+
+Note: `--load` forces `linux/amd64`, because Docker cannot load multi-arch manifests locally.
 
 ### Targets
 
 - Groups: `default`, `stack`, `services`, `skills`
-- Individual targets are defined in `docker-bake.hcl`
+- The individual targets are defined in `docker-bake.hcl`
 
 ### Configuration
 
-Defaults are defined in `docker-bake.hcl` and `scripts/bake.sh`:
+`docker-bake.hcl` and `scripts/bake.sh` define the defaults:
 
 - `REGISTRY` (default `docker.io/smartgic`)
+- `MIRROR_REGISTRY` (default empty; CI uses `ghcr.io/openvoiceos`): a second registry each image is also pushed to
 - `TAG` and `VERSION` (default `alpha`)
-- `LATEST_TAG` (default `latest`, only applied when `TAG=stable`)
-- `CHANNEL` (default `alpha`, used for constraints files)
-- `OVOS_RELEASES_REF` (default `main`, git ref of [ovos-releases](https://github.com/OpenVoiceOS/ovos-releases) the `constraints-${CHANNEL}.txt` file is taken from; pass a commit SHA for a reproducible build)
-- `CACHE_REPO` (default `ghcr.io/openvoiceos/ovos-docker-cache`, registry build cache, read anonymously) and `CACHE_TO` (default off; `max` exports the cache, CI does this)
-- `SKILLS` (list of skill names built as `skill-<name>` from `skills/skill-<name>`; edit it in `docker-bake.hcl` to add a skill)
+- `LATEST_TAG` (default `latest`; applied only when `TAG=stable`)
+- `CHANNEL` (default `alpha`): selects the constraints file
+- `OVOS_RELEASES_REF` (default `main`): the git ref of [ovos-releases](https://github.com/OpenVoiceOS/ovos-releases) that supplies `constraints-${CHANNEL}.txt`. Give a commit SHA for a reproducible build.
+- `CACHE_REPO` (default `ghcr.io/openvoiceos/ovos-docker-cache`): the registry build cache, readable without login
+- `CACHE_TO` (default off): set `max` to also export the build cache. CI does this.
+- `SKILLS`: the list of skill names. Each name builds `skill-<name>` from `skills/skill-<name>`. Add a skill here.
 - `PLATFORMS` (default `linux/amd64,linux/arm64`)
-- `UV_PRERELEASE` (default `allow`)
-- `ENSURE_BINFMT` (default `auto`, set `true` to force or `false` to skip)
-- `BUILDER` (default `ovos-bake`)
+- `UV_PRERELEASE` (default `allow`): the `uv pip` pre-release policy. Use `if-necessary-or-explicit` for `testing` and `stable`.
+- `ENSURE_BINFMT` (default `auto`): set `true` to force the binfmt installation, or `false` to skip it
+- `BUILDER` (default `ovos-bake`): the Buildx builder name
 
 Examples:
 
 - `REGISTRY=docker.io/smartgic TAG=alpha CHANNEL=alpha ./scripts/bake.sh`
-- `TAG=stable CHANNEL=stable ./scripts/bake.sh -T services`
-- `OVOS_RELEASES_REF=<commit sha> ./scripts/bake.sh -T listener` (pin the constraints to one ovos-releases commit)
+- `TAG=stable CHANNEL=stable UV_PRERELEASE=if-necessary-or-explicit ./scripts/bake.sh -T services`
+- `OVOS_RELEASES_REF=<commit sha> ./scripts/bake.sh -T listener`
 
 ## Automation
 
-Images are built by GitHub Actions on native amd64 and arm64 runners and published as multi-arch
-manifest lists (see `.github/workflows/`):
+GitHub Actions builds the images on native `amd64` and `arm64` runners and publishes them as
+multi-arch manifest lists. The workflows are in `.github/workflows/`:
 
 | Workflow | Trigger | What it builds |
 |---|---|---|
-| `on-push.yml` | commit on `dev` | the targets whose build context changed, plus everything built on top of them, for `alpha`, `testing` and `stable` |
-| `on-constraints.yml` | `repository_dispatch` from ovos-releases, hourly poll, manual | per channel, the images that contain a package whose `constraints-<channel>.txt` line changed since they were last built |
-| `pull-request.yml` | pull request | the affected targets, both architectures, no push |
-| `scheduled-rebuild.yml` | weekly | every image of a channel |
-| `build-images.yml` | called by the above, or manually | the reusable build: resolve → build per arch → verify (labels, platform, runtime smoke test on each arch) + vulnerability scan → merge (+ cosign, `<channel>-YYYYMMDD` tag) |
+| `on-push.yml` | A commit on `dev` | The targets whose build context changed, plus the targets built on top of them, for `alpha`, `testing`, and `stable` |
+| `on-constraints.yml` | A `repository_dispatch` from ovos-releases, an hourly poll, or a manual run | For each channel, the images that contain a package whose `constraints-<channel>.txt` line changed since the last build |
+| `pull-request.yml` | A pull request | The affected targets, for both architectures, without a push |
+| `scheduled-rebuild.yml` | Once a week | Every image of a channel |
+| `build-images.yml` | The workflows above, or a manual run | The reusable build: resolve, build per architecture, verify (labels, platform, a runtime smoke test on each architecture), scan for vulnerabilities, then merge (with a cosign signature and a `<channel>-YYYYMMDD` tag) |
+| `record-state.yml` | The end of a publishing run | The `build-state` branch: what each channel was built from |
 
-`scripts/affected.py` is the selector; the `build-state` branch records what each channel was built
-from (digest, ovos-releases commit, installed packages). Every image carries the label
-`io.openvoiceos.constraints.ref` with the ovos-releases commit its constraints came from.
+`scripts/affected.py` selects the targets. The `build-state` branch records, for each
+channel, the digest, the ovos-releases commit, and the installed packages of each image. Each
+image carries the label `io.openvoiceos.constraints.ref` with the ovos-releases commit that
+supplied its constraints.
 
 ## Related projects
 
-- [OpenVoiceOS/ovos-core](https://github.com/OpenVoiceOS/ovos-core): the core runtime this repo packages
+- [OpenVoiceOS/ovos-core](https://github.com/OpenVoiceOS/ovos-core): the core runtime that these images package
+- [OpenVoiceOS/ovos-installer](https://github.com/OpenVoiceOS/ovos-installer): installs Open Voice OS with these images, or in a virtual environment
+- [OpenVoiceOS/ovos-releases](https://github.com/OpenVoiceOS/ovos-releases): the constraints files that pin the packages of each channel
 - [OpenVoiceOS/ovos-docker-stt](https://github.com/OpenVoiceOS/ovos-docker-stt): speech-to-text container images
 - [OpenVoiceOS/ovos-docker-tts](https://github.com/OpenVoiceOS/ovos-docker-tts): text-to-speech container images
+- [JarbasHiveMind/hivemind-docker](https://github.com/JarbasHiveMind/hivemind-docker): HiveMind container images
 
 ## Support
 
 - [Matrix channel](https://matrix.to/#/#openvoiceos:matrix.org)
 - [Contribute to Open Voice OS](https://openvoiceos.github.io/community-docs/contributing/)
-- [Report bugs related to these Docker images](https://github.com/OpenVoiceOS/ovos-docker/issues)
+- [Report bugs related to these container images](https://github.com/OpenVoiceOS/ovos-docker/issues)
 
 ## License
 
-This repo is under the [Apache License 2.0](LICENSE).
+This repository is under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
Rewrites README.md in Simplified Technical English (short sentences, active voice, one instruction per sentence) — original rewrite by @JarbasAl, reworked on top of the current `dev` so the facts match the repository as it is today:

- no GUI images (removed in #149); `ovos-skill-base` listed with the base layers
- three channels (`alpha`, `testing`, `stable`), `latest` == `stable`, immutable `<channel>-YYYYMMDD` tags
- the `ghcr.io/openvoiceos` mirror
- build variables added this month: `MIRROR_REGISTRY`, `OVOS_RELEASES_REF`, `CACHE_REPO`/`CACHE_TO`, `SKILLS`; the `UV_PRERELEASE` guidance per channel
- the automation table, including `record-state.yml` and what `build-images.yml` verifies
- per-image `HEALTHCHECK`, SBOM, provenance and cosign signature
- Related projects extended with ovos-installer, ovos-releases and hivemind-docker; License section kept

All badges and commands are current. Rebased on `dev` (Jarbas's original commit kept, one rework commit on top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
