### PR TITLE
[ci] Verify and merge only the requested bake targets

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -104,9 +104,13 @@ jobs:
         run: |
           # shellcheck disable=SC2086
           docker buildx bake --print $TARGETS > bake.json
-          # concrete targets (groups expanded) and, for each, the repository the image lives in
-          jq -c '.target | keys' bake.json | tee targets.json
-          jq -c '.target | with_entries(.value = (.value.tags[0] | split(":")[0]))' bake.json | tee images.json
+          # Requested targets with groups expanded. `.target` also lists targets pulled in only as
+          # build contexts (e.g. base for messagebus); bake builds those but does not push them,
+          # so verify/merge must only look at what was actually requested.
+          jq -c '. as $b
+                 | def expand: if $b.group[.] != null then ($b.group[.].targets[] | expand) else . end;
+                 [ $b.group.default.targets[] | expand ] | unique' bake.json | tee targets.json
+          jq -c --slurpfile t targets.json '.target | with_entries(select(.key as $k | $t[0] | index($k))) | with_entries(.value = (.value.tags[0] | split(":")[0]))' bake.json | tee images.json
           echo "list=$(cat targets.json)" >> "$GITHUB_OUTPUT"
           echo "images=$(cat images.json)" >> "$GITHUB_OUTPUT"
 
@@ -249,6 +253,7 @@ jobs:
       - name: Create manifest lists
         env:
           TARGETS: ${{ inputs.targets }}
+          TARGET_LIST: ${{ needs.resolve.outputs.targets }}
           REGISTRY: ${{ inputs.registry }}
           TAG: ${{ inputs.channel }}
           CHANNEL: ${{ inputs.channel }}
@@ -256,7 +261,7 @@ jobs:
           # The bake file decides the final tags (<repo>:<channel>, plus :latest when stable).
           # shellcheck disable=SC2086
           docker buildx bake --print $TARGETS > bake.json
-          for target in $(jq -r '.target | keys[]' bake.json); do
+          for target in $(echo "$TARGET_LIST" | jq -r '.[]'); do
             mapfile -t tags < <(jq -r --arg t "$target" '.target[$t].tags[]' bake.json)
             repo="${tags[0]%%:*}"
             args=()
@@ -268,6 +273,7 @@ jobs:
       - name: Summary
         env:
           TARGETS: ${{ inputs.targets }}
+          TARGET_LIST: ${{ needs.resolve.outputs.targets }}
           REGISTRY: ${{ inputs.registry }}
           TAG: ${{ inputs.channel }}
         run: |
@@ -277,7 +283,8 @@ jobs:
             echo "| Image | Platforms |"
             echo "|---|---|"
             # shellcheck disable=SC2086
-            for t in $(docker buildx bake --print $TARGETS | jq -r '.target[].tags[0]' | sort -u); do
+            docker buildx bake --print $TARGETS > bake.json
+            for t in $(echo "$TARGET_LIST" | jq -r '.[]' | xargs -I{} jq -r --arg t {} '.target[$t].tags[0]' bake.json | sort -u); do
               p=$(docker buildx imagetools inspect "$t" --format '{{range .Manifest.Manifests}}{{if ne .Platform.Architecture "unknown"}}{{.Platform.OS}}/{{.Platform.Architecture}} {{end}}{{end}}')
               echo "| \`$t\` | $p |"
             done


### PR DESCRIPTION
First `push=true` run ([33319766045](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33319766045), `targets=messagebus`) built and pushed both arch images fine but failed in `verify`: it looked for `ovos-base:alpha-amd64`/`-arm64`, which were never pushed.

`bake --print messagebus` lists `base` under `.target` because it is pulled in as a build context, but `bake --push` only pushes the *requested* targets. `resolve` now expands the requested targets through the `group` section of `--print` output (groups like `stack`/`default` recurse to concrete targets) and `verify`, `merge` and the summary use that list.

Re-run of the same push from this branch: [33319968653](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33319968653).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image builds now process only the explicitly requested targets.
  * Dependency-only build contexts are excluded from image metadata and summaries.
  * Build and merge results now accurately reflect the selected targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->