### PR TITLE
[ci] Pre-release policy follows the channel

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -32,8 +32,9 @@ on:
         type: string
         default: docker.io/smartgic
       uv_prerelease:
+        description: "uv --prerelease mode; auto = allow for alpha, if-necessary-or-explicit for testing/stable"
         type: string
-        default: allow
+        default: auto
     secrets:
       DOCKERHUB_USERNAME:
         required: false
@@ -64,9 +65,9 @@ on:
         type: string
         default: docker.io/smartgic
       uv_prerelease:
-        description: uv --prerelease mode
+        description: "uv --prerelease mode (auto = allow for alpha, if-necessary-or-explicit otherwise)"
         type: string
-        default: allow
+        default: auto
 
 permissions:
   contents: read
@@ -80,6 +81,7 @@ jobs:
       targets: ${{ steps.targets.outputs.list }}
       images: ${{ steps.targets.outputs.images }}
       build_date: ${{ steps.meta.outputs.build_date }}
+      uv_prerelease: ${{ steps.pre.outputs.mode }}
     steps:
       - uses: actions/checkout@v7
 
@@ -117,6 +119,23 @@ jobs:
       - name: Build metadata
         id: meta
         run: echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Effective prerelease mode
+        id: pre
+        env:
+          MODE: ${{ inputs.uv_prerelease }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          # constraints-alpha.txt pins pre-releases (>=x.y.za1); testing/stable are stable version ranges,
+          # so pre-releases must not be pulled into them.
+          if [ "$MODE" = "auto" ]; then
+            case "$CHANNEL" in
+              alpha) MODE=allow ;;
+              *)     MODE=if-necessary-or-explicit ;;
+            esac
+          fi
+          echo "channel=$CHANNEL -> uv --prerelease=$MODE"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build ${{ matrix.arch }}
@@ -175,7 +194,7 @@ jobs:
           TAG: ${{ inputs.channel }}-${{ matrix.arch }}
           CHANNEL: ${{ inputs.channel }}
           VERSION: ${{ inputs.channel }}
-          UV_PRERELEASE: ${{ inputs.uv_prerelease }}
+          UV_PRERELEASE: ${{ needs.resolve.outputs.uv_prerelease }}
           OVOS_RELEASES_REF: ${{ needs.resolve.outputs.ovos_releases_sha }}
           BUILD_DATE: ${{ needs.resolve.outputs.build_date }}
           GIT_SHA: ${{ github.sha }}

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -49,6 +49,7 @@ FROM ${SOUND_BASE_IMAGE} AS builder
 ARG OVOS_CHANNEL=alpha
 ENV OVOS_CHANNEL=${OVOS_CHANNEL}
 ARG OVOS_RELEASES_REF=main
+ARG UV_PRERELEASE=allow
 
 USER root
 SHELL ["/bin/bash", "-c"]
@@ -65,10 +66,10 @@ COPY files/requirements.txt /tmp/requirements.txt
 
 ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${OVOS_RELEASES_REF}/constraints-${OVOS_CHANNEL}.txt /tmp/constraints.txt
 
-# ✅ allow pre-releases while building the wheelhouse
+# pre-releases only for the alpha channel (UV_PRERELEASE=allow)
 RUN --mount=type=cache,target=/root/.cache/pip \
     PIP_NO_CACHE_DIR=0 python -m pip install --upgrade pip setuptools wheel \
- && PIP_NO_CACHE_DIR=0 python -m pip wheel --pre -r /tmp/requirements.txt \
+ && PIP_NO_CACHE_DIR=0 python -m pip wheel $( [ "${UV_PRERELEASE}" = "allow" ] && echo --pre ) -r /tmp/requirements.txt \
         -c /tmp/constraints.txt \
         -w /tmp/wheels
 
@@ -77,6 +78,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ############################
 FROM runtime
 ARG USER=ovos
+ARG UV_PRERELEASE=allow
 USER root
 SHELL ["/bin/bash", "-c"]
 
@@ -89,8 +91,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY --from=builder /tmp/wheels /tmp/wheels
 COPY --from=builder /tmp/requirements.txt /tmp/requirements.txt
 
-# ✅ allow pre-releases during offline install too
-RUN python -m pip install --no-index --find-links=/tmp/wheels --pre -r /tmp/requirements.txt \
+# same pre-release policy for the offline install
+RUN python -m pip install --no-index --find-links=/tmp/wheels $( [ "${UV_PRERELEASE}" = "allow" ] && echo --pre ) -r /tmp/requirements.txt \
  && mkdir -p "/home/${USER}/.local/share/mycroft/skills" "/home/${USER}/nltk_data" \
  && chown "${USER}:${USER}" -R "/home/${USER}" \
  && rm -rf /tmp/wheels /tmp/requirements.txt


### PR DESCRIPTION
`constraints-alpha.txt` pins pre-releases (`>=x.y.za1`), but `constraints-testing.txt` and `constraints-stable.txt` are ranges of **stable** versions (`ovos-dinkum-listener>=0.5.0,<1.0.0`). Building those channels with `uv --prerelease=allow` (the bake default) or `pip wheel --pre` (hardcoded in `core/Dockerfile`) lets alphas inside the range — e.g. `0.9.0a1` — leak into `testing`/`stable` images.

- **`build-images.yml`**: `uv_prerelease` input now defaults to `auto` → `allow` for `alpha`, `if-necessary-or-explicit` for every other channel (resolved in the `resolve` job, still overridable).
- **`core/Dockerfile`**: `--pre` is passed to `pip wheel` / the offline `pip install` only when `UV_PRERELEASE=allow`. Without `--pre`, pip still honours pre-releases named explicitly in a specifier, which matches uv's `if-necessary-or-explicit`.

No change for the alpha channel. `latest` ↔ `stable` mapping is unchanged (the bake file adds `:latest` when `TAG == "stable"`, and `merge` takes its tag list from the bake file).

Verification runs from this branch, `targets=messagebus push=true`: [testing 33320266703](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33320266703), [stable 33320267738](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33320267738) — results in the comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)