### PR TITLE
[ci] Expand requested targets from the TARGETS input

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -104,12 +104,18 @@ jobs:
         run: |
           # shellcheck disable=SC2086
           docker buildx bake --print $TARGETS > bake.json
-          # Requested targets with groups expanded. `.target` also lists targets pulled in only as
-          # build contexts (e.g. base for messagebus); bake builds those but does not push them,
-          # so verify/merge must only look at what was actually requested.
-          jq -c '. as $b
+          # Requested targets with groups expanded, starting from the TARGETS input itself (each word is a
+          # group or a target; groups may nest). `.target` also lists targets pulled in only as build
+          # contexts (e.g. base for messagebus); bake builds those but does not push them, so
+          # verify/merge must only look at what was actually requested.
+          # shellcheck disable=SC2086
+          printf '%s\n' $TARGETS | jq -R . | jq -sc '.' > roots.json
+          jq -c --slurpfile roots roots.json '. as $b
                  | def expand: if $b.group[.] != null then ($b.group[.].targets[] | expand) else . end;
-                 [ $b.group.default.targets[] | expand ] | unique' bake.json | tee targets.json
+                 [ $roots[0][] | expand ] | unique' bake.json | tee targets.json
+          # every resolved name must be a real target
+          jq -e --slurpfile t targets.json '($t[0] - (.target | keys)) == []' bake.json > /dev/null \
+            || { echo "::error::unknown target(s): $(jq -c --slurpfile t targets.json '$t[0] - (.target | keys)' bake.json)"; exit 1; }
           jq -c --slurpfile t targets.json '.target | with_entries(select(.key as $k | $t[0] | index($k))) | with_entries(.value = (.value.tags[0] | split(":")[0]))' bake.json | tee images.json
           echo "list=$(cat targets.json)" >> "$GITHUB_OUTPUT"
           echo "images=$(cat images.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Addresses CodeRabbit's finding on #128 (thread on `build-images.yml:112`).

The successful `messagebus` push run showed `bake --print <targets>` does emit a synthetic `group.default` containing only the requested targets, so the previous code worked — but expanding from the `targets` input itself is more obviously correct and doesn't depend on that buildx behaviour. Each word of `targets` is now a root (group or target, groups may nest), and an unknown name fails `resolve` early instead of surfacing later as a missing image.

Tested against buildx-shaped output: `messagebus stack` → `[base, core, messagebus, sound-base]`; nested `everything` → expands through `stack`; `bogus` → error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)