### PR TITLE
[ci] Label every image with the constraints ref; report all verify failures

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -233,6 +233,7 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           EXPECTED_REF: ${{ needs.resolve.outputs.ovos_releases_sha }}
         run: |
+          set +e   # report every bad image, then fail once at the end
           fail=0
           for repo in $(echo "$IMAGES" | jq -r '.[]' | sort -u); do
             for arch in amd64 arm64; do
@@ -240,7 +241,7 @@ jobs:
               if ! docker buildx imagetools inspect "$ref" --format '{{json .Image}}' > image.json 2> err.txt; then
                 echo "::error::${ref}: $(cat err.txt)"; fail=1; continue
               fi
-              python3 - "$ref" "$arch" "$EXPECTED_REF" <<'PY'
+              if python3 - "$ref" "$arch" "$EXPECTED_REF" <<'PY'
           import json, sys
           ref, arch, expected = sys.argv[1:]
           obj = json.load(open("image.json"))
@@ -252,7 +253,7 @@ jobs:
           print(f"{'OK ' if ok else 'BAD'} {ref}: architecture={got_arch} constraints.ref={got_ref}")
           sys.exit(0 if ok else 1)
           PY
-              [ $? -eq 0 ] || fail=1
+              then :; else fail=1; fi
             done
           done
           exit $fail

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,6 +6,7 @@ ARG CHANNEL=alpha
 ARG VERSION=unknown
 ARG IMAGE_REF=ovos-base:alpha
 ARG GIT_SHA=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="Open Voice OS OCI base image" \
       org.opencontainers.image.description="Used as base layer for other OCI images" \
@@ -19,7 +20,8 @@ LABEL org.opencontainers.image.title="Open Voice OS OCI base image" \
       org.opencontainers.image.base.name="python:3.13.11-slim-trixie@sha256:56ab277ddf459858f94052252565945c34617c841818faf8f34f6896de06cffe" \
       org.opencontainers.image.url="https://openvoiceos.github.io/ovos-docker" \
       org.opencontainers.image.ref.name="${IMAGE_REF}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
 ARG USER=ovos
 ARG USER_UID=1000

--- a/gui/gui-original/Dockerfile
+++ b/gui/gui-original/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:13@sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9
 ARG TAG=0.1.0
 ARG REGISTRY=docker.io/smartgic
 ARG GIT_SHA=unknown
+ARG OVOS_RELEASES_REF=main
 
 
 ARG BUILD_DATE=unknown
@@ -20,6 +21,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.url="https://openvoiceos.github.io/ovos-docker"
 LABEL org.opencontainers.image.ref.name="${REGISTRY}/ovos-gui-original:${TAG}"
 LABEL org.opencontainers.image.revision="${GIT_SHA}"
+LABEL io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
 ARG BRANCH_OVOS=master
 ARG BRANCH_MYCROFT=dev

--- a/gui/gui-shell/Dockerfile
+++ b/gui/gui-shell/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:13@sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9
 ARG TAG=0.1.0
 ARG REGISTRY=docker.io/smartgic
 ARG GIT_SHA=unknown
+ARG OVOS_RELEASES_REF=main
 
 
 ARG BUILD_DATE=unknown
@@ -20,6 +21,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.url="https://openvoiceos.github.io/ovos-docker"
 LABEL org.opencontainers.image.ref.name="${REGISTRY}/ovos-gui-shell:${TAG}"
 LABEL org.opencontainers.image.revision="${GIT_SHA}"
+LABEL io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
 ARG BRANCH_OVOS=master
 ARG BRANCH_MYCROFT=dev

--- a/sound-base/Dockerfile
+++ b/sound-base/Dockerfile
@@ -15,6 +15,7 @@ ARG BUILD_DATE=unknown
 ARG VERSION=unknown
 ARG IMAGE_REF=ovos-sound-base:dev
 ARG GIT_SHA=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="Open Voice OS OCI sound base image" \
       org.opencontainers.image.description="Sound base layer for audio related images" \
@@ -28,7 +29,8 @@ LABEL org.opencontainers.image.title="Open Voice OS OCI sound base image" \
       org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.url="https://openvoiceos.github.io/ovos-docker" \
       org.opencontainers.image.ref.name="${IMAGE_REF}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
 ARG USER=ovos
 USER root


### PR DESCRIPTION
The first full `alpha` bootstrap ([33320591174](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33320591174)) built all 35 targets on both arches but failed in `verify`: `base`, `sound-base`, `gui-original` and `gui-shell` carry no `io.openvoiceos.constraints.ref` label (they install no OVOS packages). As designed, `merge` was skipped and no `:alpha` tag moved.

- Every bake target now declares `ARG OVOS_RELEASES_REF` and the label, so the check is uniform and every image records the ovos-releases ref of the pipeline run that produced it.
- `verify` ran under `bash -e` and aborted at the first bad image (only `ovos-base` was reported); it now checks all images and fails once at the end with the complete list.

Re-run of the three-channel bootstrap from this branch linked in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)