### PR TITLE
[ci] Record build state from a workflow_run workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -10,6 +10,10 @@ name: Build images
 # merge work on digests, two overlapping runs of the same channel can never be mixed, and a
 # failed or missing arch never moves the tag the installer pulls.
 #
+# What was published is handed to record-state.yml (workflow_run) as an artifact; that workflow
+# writes the build-state branch with its own permissions, so this one only needs contents: read
+# and can be called from pull requests, including forks.
+#
 # The build cache lives on GHCR (ghcr.io/openvoiceos/ovos-docker-cache), which has no pull-rate
 # limits; Docker Hub only sees the image pushes themselves.
 
@@ -90,7 +94,7 @@ on:
         default: true
 
 permissions:
-  contents: write   # build-state branch (what each channel was built from)
+  contents: read
   packages: write   # GHCR build cache
   id-token: write   # cosign keyless signing
 
@@ -369,36 +373,20 @@ jobs:
                '. + [{target: $t, repo: $r, digest: $d, amd64_digest: $a}]' entries.json > entries.tmp && mv entries.tmp entries.json
           done
 
-      - name: Record build state
+      - name: Hand what was published to record-state.yml
         env:
           CHANNEL: ${{ inputs.channel }}
           OVOS_RELEASES_SHA: ${{ needs.resolve.outputs.ovos_releases_sha }}
         run: |
-          # state/<channel>.json on the build-state branch: repo, digest, constraints ref and the Python
-          # packages (from the SBOM) of every image just published. scripts/affected.py reads it to decide
-          # what a constraints change requires rebuilding, without any registry request.
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code --heads origin build-state > /dev/null 2>&1; then
-            git fetch --depth=1 origin build-state
-            git worktree add state-wt FETCH_HEAD
-            git -C state-wt checkout -q -B build-state
-          else
-            git worktree add --detach state-wt
-            git -C state-wt checkout -q --orphan build-state
-            git -C state-wt rm -rfq .
-            printf '# build-state\n\nWhat each channel was last built from. Written by build-images.yml, read by scripts/affected.py.\n' > state-wt/README.md
-          fi
-          mkdir -p state-wt/state
-          python3 scripts/ci/record-state.py "state-wt/state/${CHANNEL}.json" "$CHANNEL" "$OVOS_RELEASES_SHA" entries.json
-          git -C state-wt add -A
-          git -C state-wt commit -qm "state(${CHANNEL}): $(jq length entries.json) image(s) from ovos-releases@${OVOS_RELEASES_SHA:0:7}"
-          for attempt in 1 2 3 4 5; do
-            git -C state-wt push origin build-state && break
-            echo "push rejected (attempt ${attempt}); rebasing on the current build-state"
-            git -C state-wt fetch origin build-state
-            git -C state-wt rebase FETCH_HEAD
-          done
+          mkdir -p build-state
+          cp entries.json build-state/entries.json
+          printf '{"channel": "%s", "ovos_releases_ref": "%s"}\n' "$CHANNEL" "$OVOS_RELEASES_SHA" > build-state/meta.json
+
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: build-state-${{ inputs.channel }}
+          path: build-state/
+          retention-days: 7
 
       - name: Summary
         env:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -382,7 +382,7 @@ jobs:
           cp entries.json build-state/entries.json
           printf '{"channel": "%s", "ovos_releases_ref": "%s"}\n' "$CHANNEL" "$OVOS_RELEASES_SHA" > build-state/meta.json
 
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-state-${{ inputs.channel }}
           path: build-state/

--- a/.github/workflows/record-state.yml
+++ b/.github/workflows/record-state.yml
@@ -1,0 +1,85 @@
+name: Record build state
+
+# After a publishing run completes, writes state/<channel>.json on the build-state branch: for
+# every image just published, its repository, manifest-list digest, the ovos-releases commit its
+# constraints came from and the Python packages it contains (from the SBOM). scripts/affected.py
+# reads this to decide what a constraints change requires rebuilding, without any registry request.
+#
+# Runs as a separate workflow (workflow_run) so build-images.yml itself never needs write access
+# to the repository and can be called from pull requests, including forks.
+
+on:
+  workflow_run:
+    workflows: ["Build images", "Publish on push", "Publish on constraints change", "Weekly rebuild"]
+    types: [completed]
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: build-state
+  cancel-in-progress: false
+
+jobs:
+  record:
+    name: Record
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Download what the run published
+        id: dl
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          mkdir -p handoff
+          gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" --pattern 'build-state-*' --dir handoff 2> dl.err || true
+          n=$(find handoff -name meta.json | wc -l)
+          echo "artifacts=$n" >> "$GITHUB_OUTPUT"
+          echo "run ${RUN_ID}: ${n} channel artifact(s)"
+          [ "$n" = "0" ] && cat dl.err || true
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+        if: steps.dl.outputs.artifacts != '0'
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        if: steps.dl.outputs.artifacts != '0'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Update the build-state branch
+        if: steps.dl.outputs.artifacts != '0'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --heads origin build-state > /dev/null 2>&1; then
+            git fetch --depth=1 origin build-state
+            git worktree add state-wt FETCH_HEAD
+            git -C state-wt checkout -q -B build-state
+          else
+            git worktree add --detach state-wt
+            git -C state-wt checkout -q --orphan build-state
+            git -C state-wt rm -rfq .
+            printf '# build-state\n\nWhat each channel was last built from. Written by record-state.yml, read by scripts/affected.py.\n' > state-wt/README.md
+          fi
+          mkdir -p state-wt/state
+          msg=""
+          for meta in handoff/*/meta.json; do
+            dir=$(dirname "$meta")
+            channel=$(jq -r .channel "$meta"); ref=$(jq -r .ovos_releases_ref "$meta")
+            python3 scripts/ci/record-state.py "state-wt/state/${channel}.json" "$channel" "$ref" "$dir/entries.json"
+            msg="${msg}${channel}: $(jq length "$dir/entries.json") image(s) from ovos-releases@${ref:0:7}; "
+          done
+          git -C state-wt add -A
+          if git -C state-wt diff --cached --quiet; then echo "nothing changed"; exit 0; fi
+          git -C state-wt commit -qm "state: ${msg}"
+          for attempt in 1 2 3 4 5; do
+            git -C state-wt push origin build-state && break
+            echo "push rejected (attempt ${attempt}); rebasing on the current build-state"
+            git -C state-wt fetch origin build-state
+            git -C state-wt rebase FETCH_HEAD
+          done


### PR DESCRIPTION
The first PR after #134 (Renovate's `renovate/pin-dependencies`) made `pull-request.yml` fail at **startup**: a called workflow cannot request more permissions than its caller, and `build-images.yml` asked for `contents: write` (to push the `build-state` branch) while a `pull_request` caller only has `contents: read`.

Structural fix rather than granting write to PR callers (which would still fail for fork PRs):
- `build-images.yml` → `contents: read`. The `merge` job hands what it published (entries + channel + constraints ref) to an artifact `build-state-<channel>`.
- new `record-state.yml` → `on: workflow_run` (completed, success) for the publishing workflows; downloads those artifacts and writes `state/<channel>.json` on `build-state` with its own `contents: write`. Serialized by a concurrency group.

This PR is itself the test: its `PR build` check must start (and build `messagebus`, since workflow files changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)