### PR TITLE
[ci] Push to a GHCR mirror and read everything from it

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -14,8 +14,11 @@ name: Build images
 # writes the build-state branch with its own permissions, so this one only needs contents: read
 # and can be called from pull requests, including forks.
 #
-# The build cache lives on GHCR (ghcr.io/openvoiceos/ovos-docker-cache), which has no pull-rate
-# limits; Docker Hub only sees the image pushes themselves.
+# Docker Hub (the registry users pull from) counts every manifest GET against a small hourly
+# budget, so the pipeline never reads from it: every image is also pushed to a GHCR mirror
+# (ghcr.io/openvoiceos, no pull-rate limit) and verify, manifest creation, inspection and SBOM
+# reads use the mirror. Hub only receives pushes and the cosign signatures. The build cache lives
+# on GHCR as well.
 
 on:
   workflow_call:
@@ -39,6 +42,10 @@ on:
       registry:
         type: string
         default: docker.io/smartgic
+      mirror_registry:
+        description: Second registry every image is pushed to; the pipeline reads from it (no pull-rate limit)
+        type: string
+        default: ghcr.io/openvoiceos
       uv_prerelease:
         description: "uv --prerelease mode; auto = allow for alpha, if-necessary-or-explicit for testing/stable"
         type: string
@@ -77,9 +84,13 @@ on:
         type: boolean
         default: false
       registry:
-        description: Registry
+        description: Registry users pull from
         type: string
         default: docker.io/smartgic
+      mirror_registry:
+        description: Second registry the pipeline pushes to and reads from
+        type: string
+        default: ghcr.io/openvoiceos
       uv_prerelease:
         description: "uv --prerelease mode (auto = allow for alpha, if-necessary-or-explicit otherwise)"
         type: string
@@ -145,7 +156,7 @@ jobs:
           # every resolved name must be a real target
           jq -e --slurpfile t targets.json '($t[0] - (.target | keys)) == []' bake.json > /dev/null \
             || { echo "::error::unknown target(s): $(jq -c --slurpfile t targets.json '$t[0] - (.target | keys)' bake.json)"; exit 1; }
-          # target -> repository (tag stripped)
+          # target -> repository (tag stripped), on the user-facing registry
           jq -c --slurpfile t targets.json '.target | with_entries(select(.key as $k | $t[0] | index($k))) | with_entries(.value = (.value.tags[0] | split(":")[0]))' bake.json | tee images.json
           echo "list=$(cat targets.json)" >> "$GITHUB_OUTPUT"
           echo "images=$(cat images.json)" >> "$GITHUB_OUTPUT"
@@ -228,6 +239,7 @@ jobs:
       - name: Bake ${{ inputs.targets }} for ${{ matrix.platform }}
         env:
           REGISTRY: ${{ inputs.registry }}
+          MIRROR_REGISTRY: ${{ inputs.mirror_registry }}
           # arch-suffixed tag; the channel tag is created by the merge job from digests
           TAG: ${{ inputs.channel }}-${{ matrix.arch }}
           CHANNEL: ${{ inputs.channel }}
@@ -267,8 +279,9 @@ jobs:
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -280,11 +293,14 @@ jobs:
           TARGETS: ${{ needs.resolve.outputs.targets }}
           IMAGES: ${{ needs.resolve.outputs.images }}
           EXPECTED_REF: ${{ needs.resolve.outputs.ovos_releases_sha }}
+          REGISTRY: ${{ inputs.registry }}
+          MIRROR: ${{ inputs.mirror_registry }}
         run: |
           set +e   # report every bad image, then fail once at the end
           fail=0
           for target in $(echo "$TARGETS" | jq -r '.[]'); do
-            repo=$(echo "$IMAGES" | jq -r --arg t "$target" '.[$t]')
+            # digests are identical on both registries; read from the mirror (no pull-rate limit)
+            repo=$(echo "$IMAGES" | jq -r --arg t "$target" '.[$t]' | sed "s#^${REGISTRY}/#${MIRROR}/#")
             for arch in amd64 arm64; do
               digest=$(jq -r --arg t "$target" '.[$t]["containerimage.digest"] // empty' "bake-meta-${arch}.json")
               if [ -z "$digest" ]; then echo "::error::${target}/${arch}: no digest in bake metadata"; fail=1; continue; fi
@@ -327,6 +343,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: bake-meta-*
@@ -342,35 +364,41 @@ jobs:
           TARGET_LIST: ${{ needs.resolve.outputs.targets }}
           IMAGES: ${{ needs.resolve.outputs.images }}
           REGISTRY: ${{ inputs.registry }}
+          MIRROR_REGISTRY: ${{ inputs.mirror_registry }}
           TAG: ${{ inputs.channel }}
           CHANNEL: ${{ inputs.channel }}
           DATE_TAG: ${{ needs.resolve.outputs.date_tag }}
           IMMUTABLE: ${{ inputs.immutable_tag }}
           SIGN: ${{ inputs.sign }}
         run: |
-          # The bake file decides the channel tags (<repo>:<channel>, plus :latest when stable).
+          # The bake file decides the channel tags (<repo>:<channel>, plus :latest when stable), on both
+          # registries. Sources are read from the mirror: Docker Hub then only receives the manifest
+          # list (PUT) and blob existence checks (HEAD), neither of which counts as a pull.
           # shellcheck disable=SC2086
           docker buildx bake --print $TARGETS > bake.json
           echo "[]" > entries.json
           for target in $(echo "$TARGET_LIST" | jq -r '.[]'); do
             repo=$(echo "$IMAGES" | jq -r --arg t "$target" '.[$t]')
+            mirror=$(echo "$repo" | sed "s#^${REGISTRY}/#${MIRROR_REGISTRY}/#")
             mapfile -t tags < <(jq -r --arg t "$target" '.target[$t].tags[]' bake.json)
-            if [ "$IMMUTABLE" = "true" ]; then tags+=("${repo}:${CHANNEL}-${DATE_TAG}"); fi
+            if [ "$IMMUTABLE" = "true" ]; then tags+=("${repo}:${CHANNEL}-${DATE_TAG}" "${mirror}:${CHANNEL}-${DATE_TAG}"); fi
             src=()
             for arch in amd64 arm64; do
-              src+=("${repo}@$(jq -r --arg t "$target" '.[$t]["containerimage.digest"]' "bake-meta-${arch}.json")")
+              src+=("${mirror}@$(jq -r --arg t "$target" '.[$t]["containerimage.digest"]' "bake-meta-${arch}.json")")
             done
             args=()
             for t in "${tags[@]}"; do args+=(-t "$t"); done
             echo "==> ${target}: ${tags[*]}"
             printf '      <- %s\n' "${src[@]}"
             docker buildx imagetools create "${args[@]}" "${src[@]}"
-            digest=$(docker buildx imagetools inspect "${tags[0]}" --format '{{.Manifest.Digest}}')
+            # the manifest list is byte-identical on both registries, so its digest can be read from the mirror
+            digest=$(docker buildx imagetools inspect "${mirror}:${CHANNEL}" --format '{{.Manifest.Digest}}')
             if [ "$SIGN" = "true" ]; then
               cosign sign --yes "${repo}@${digest}"
+              cosign sign --yes "${mirror}@${digest}"
             fi
-            jq --arg t "$target" --arg r "$repo" --arg d "$digest" --arg a "${src[0]#*@}" \
-               '. + [{target: $t, repo: $r, digest: $d, amd64_digest: $a}]' entries.json > entries.tmp && mv entries.tmp entries.json
+            jq --arg t "$target" --arg r "$repo" --arg m "$mirror" --arg d "$digest" --arg a "${src[0]#*@}" \
+               '. + [{target: $t, repo: $r, mirror: $m, digest: $d, amd64_digest: $a}]' entries.json > entries.tmp && mv entries.tmp entries.json
           done
 
       - name: Hand what was published to record-state.yml
@@ -390,8 +418,6 @@ jobs:
 
       - name: Summary
         env:
-          TARGET_LIST: ${{ needs.resolve.outputs.targets }}
-          IMAGES: ${{ needs.resolve.outputs.images }}
           CHANNEL: ${{ inputs.channel }}
           SIGN: ${{ inputs.sign }}
         run: |
@@ -400,12 +426,10 @@ jobs:
             echo
             echo "| Image | Platforms | Digest | Signed |"
             echo "|---|---|---|---|"
-            for target in $(echo "$TARGET_LIST" | jq -r '.[]'); do
-              repo=$(echo "$IMAGES" | jq -r --arg t "$target" '.[$t]')
-              ref="${repo}:${CHANNEL}"
-              p=$(docker buildx imagetools inspect "$ref" --format '{{range .Manifest.Manifests}}{{if ne .Platform.Architecture "unknown"}}{{.Platform.OS}}/{{.Platform.Architecture}} {{end}}{{end}}')
-              d=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}')
+            for row in $(jq -c '.[]' entries.json); do
+              repo=$(echo "$row" | jq -r .repo); mirror=$(echo "$row" | jq -r .mirror); d=$(echo "$row" | jq -r .digest)
+              p=$(docker buildx imagetools inspect "${mirror}:${CHANNEL}" --format '{{range .Manifest.Manifests}}{{if ne .Platform.Architecture "unknown"}}{{.Platform.OS}}/{{.Platform.Architecture}} {{end}}{{end}}')
               s=$([ "$SIGN" = "true" ] && echo "cosign" || echo "no")
-              echo "| \`$ref\` | $p | \`${d:0:19}…\` | $s |"
+              echo "| \`${repo}:${CHANNEL}\` (+ \`${mirror}:${CHANNEL}\`) | $p | \`${d:0:19}…\` | $s |"
             done
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/record-state.yml
+++ b/.github/workflows/record-state.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: write
   actions: read
+  packages: read
 
 concurrency:
   group: build-state
@@ -48,8 +49,9 @@ jobs:
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         if: steps.dl.outputs.artifacts != '0'
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Update the build-state branch
         if: steps.dl.outputs.artifacts != '0'

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -31,6 +31,11 @@ variable "OVOS_RELEASES_REF" { default = "main" }
 variable "CACHE_REPO" { default = "ghcr.io/openvoiceos/ovos-docker-cache" }
 variable "CACHE_TO"   { default = "" }
 
+# Optional second registry every image is also pushed to (CI uses ghcr.io/openvoiceos). The pipeline
+# reads manifests, labels and SBOMs from there, which has no pull-rate limit; users keep pulling
+# from REGISTRY. Empty = single registry (local builds).
+variable "MIRROR_REGISTRY" { default = "" }
+
 # Skills built from skills/skill-<name>/Dockerfile on top of skill-base. Adding a skill = one entry here.
 variable "SKILLS" {
   default = [
@@ -60,14 +65,23 @@ variable "SKILLS" {
 
 # ---------- Helpers ----------
 # stable is additionally tagged LATEST_TAG; every other TAG is published as-is.
+# With MIRROR_REGISTRY set, the same tags are also produced for the mirror.
 function "tags" {
   params = [image]
-  result = TAG == "stable" ? [
-    "${REGISTRY}/${image}:${TAG}",
-    "${REGISTRY}/${image}:${LATEST_TAG}",
-  ] : [
-    "${REGISTRY}/${image}:${TAG}",
-  ]
+  result = compact(concat(
+    TAG == "stable" ? [
+      "${REGISTRY}/${image}:${TAG}",
+      "${REGISTRY}/${image}:${LATEST_TAG}",
+    ] : [
+      "${REGISTRY}/${image}:${TAG}",
+    ],
+    MIRROR_REGISTRY == "" ? [""] : (TAG == "stable" ? [
+      "${MIRROR_REGISTRY}/${image}:${TAG}",
+      "${MIRROR_REGISTRY}/${image}:${LATEST_TAG}",
+    ] : [
+      "${MIRROR_REGISTRY}/${image}:${TAG}",
+    ]),
+  ))
 }
 
 function "cache_from" {

--- a/scripts/bake.sh
+++ b/scripts/bake.sh
@@ -11,6 +11,7 @@ UV_PRERELEASE="${UV_PRERELEASE:-allow}"
 OVOS_RELEASES_REF="${OVOS_RELEASES_REF:-main}" # git ref of OpenVoiceOS/ovos-releases for constraints-${CHANNEL}.txt
 CACHE_REPO="${CACHE_REPO:-ghcr.io/openvoiceos/ovos-docker-cache}" # build cache on GHCR (read anonymously)
 CACHE_TO="${CACHE_TO:-}"           # "max" to also export the cache (needs GHCR write access; CI does this)
+MIRROR_REGISTRY="${MIRROR_REGISTRY:-}" # optional second registry to push to (CI: ghcr.io/openvoiceos)
 PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
 TARGETS="${TARGETS:-default}"   # can be "stack services skills guis" or individual targets
 PUSH="${PUSH:-true}"            # true -> --push
@@ -157,7 +158,7 @@ ensure_builder() {
 # Metadata
 export BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 export GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-export REGISTRY TAG LATEST_TAG VERSION CHANNEL UV_PRERELEASE OVOS_RELEASES_REF CACHE_REPO CACHE_TO
+export REGISTRY TAG LATEST_TAG VERSION CHANNEL UV_PRERELEASE OVOS_RELEASES_REF CACHE_REPO CACHE_TO MIRROR_REGISTRY
 
 echo "==> REGISTRY=$REGISTRY TAG=$TAG LATEST_TAG=$LATEST_TAG VERSION=$VERSION CHANNEL=$CHANNEL UV_PRERELEASE=$UV_PRERELEASE OVOS_RELEASES_REF=$OVOS_RELEASES_REF"
 echo "==> BUILD_DATE=$BUILD_DATE GIT_SHA=$GIT_SHA"

--- a/scripts/ci/record-state.py
+++ b/scripts/ci/record-state.py
@@ -46,10 +46,12 @@ def main():
     entries = json.load(open(entries_file))   # [{target, repo, digest, amd64_digest}]
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     for e in entries:
-        pkgs = sbom_python_packages(f"{e['repo']}@{e['amd64_digest']}")
+        # digests are identical on every registry the image was pushed to; read the SBOM from the
+        # mirror when there is one (no pull-rate limit)
+        pkgs = sbom_python_packages(f"{e.get('mirror') or e['repo']}@{e['amd64_digest']}")
         state["images"][e["target"]] = {
-            "repo": e["repo"], "digest": e["digest"], "constraints_ref": constraints_ref,
-            "packages": pkgs, "built": now,
+            "repo": e["repo"], "mirror": e.get("mirror", ""), "digest": e["digest"],
+            "constraints_ref": constraints_ref, "packages": pkgs, "built": now,
         }
         print(f"{e['target']}: {len(pkgs)} python packages", file=sys.stderr)
     state["ovos_releases_ref"] = constraints_ref


### PR DESCRIPTION
The first full `alpha` bootstrap on `dev` (run 33325061909) failed in **Create channel manifests** with `429 Too Many Requests` after base and cli were merged: `verify` → `imagetools create` → `inspect` → `cosign` → SBOM read cost ~12 manifest GETs per image on Docker Hub, and the account is Personal tier (200 pulls/hour). Docker counts manifest **GET**s only (HEAD and blob requests are free).

## Change
- `docker-bake.hcl`: new `MIRROR_REGISTRY` (empty for local builds). `tags()` also emits the mirror tags, so bake pushes every image to both registries in one build.
- `build-images.yml`: `mirror_registry` input (default `ghcr.io/openvoiceos`, GHCR login with `GITHUB_TOKEN`). `verify` reads the mirror; `merge` creates the channel manifest lists **from the mirror's digests** on both registries (Hub only gets the PUT + blob HEADs), reads the resulting digest/platforms from the mirror, signs both copies. `record-state.py` reads the SBOM from the mirror.
- Hub traffic per full channel: pushes + cosign only (~35–70 counted requests instead of ~450).

Users keep pulling from `docker.io/smartgic`; `ghcr.io/openvoiceos/ovos-*` becomes a mirror with no pull-rate limit (packages in this org are created public, as the build cache was).

Verification: the PR build (dry run) proves the HCL/workflow changes; the push path is exercised after merge with `channel=alpha targets=messagebus push=true`, then the alpha bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
