### PR TITLE
[ci] Sign on the mirror, copy the signature to Docker Hub

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -358,6 +358,10 @@ jobs:
         if: inputs.sign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
+      - name: Install crane
+        if: inputs.sign
+        uses: imjasonh/setup-crane@ # v0.4
+
       - name: Create manifest lists from the verified digests
         env:
           TARGETS: ${{ inputs.targets }}
@@ -394,8 +398,12 @@ jobs:
             # the manifest list is byte-identical on both registries, so its digest can be read from the mirror
             digest=$(docker buildx imagetools inspect "${mirror}:${CHANNEL}" --format '{{.Manifest.Digest}}')
             if [ "$SIGN" = "true" ]; then
-              cosign sign --yes "${repo}@${digest}"
-              cosign sign --yes "${mirror}@${digest}"
+              # Sign on the mirror (no pull-rate limit), then copy the signature artifact
+              # (<repo>:sha256-<digest>.sig) to the user-facing registry: the signature is bound to the
+              # digest, which is the same on both, and copying only costs Hub a PUT and blob HEADs.
+              for attempt in 1 2 3; do cosign sign --yes "${mirror}@${digest}" && break; echo "cosign attempt ${attempt} failed; retrying"; sleep 30; done
+              sig="sha256-${digest#sha256:}.sig"
+              for attempt in 1 2 3; do crane copy "${mirror}:${sig}" "${repo}:${sig}" && break; echo "signature copy attempt ${attempt} failed; retrying"; sleep 30; done
             fi
             jq --arg t "$target" --arg r "$repo" --arg m "$mirror" --arg d "$digest" --arg a "${src[0]#*@}" \
                '. + [{target: $t, repo: $r, mirror: $m, digest: $d, amd64_digest: $a}]' entries.json > entries.tmp && mv entries.tmp entries.json

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -140,6 +140,7 @@ jobs:
         env:
           TARGETS: ${{ inputs.targets }}
           REGISTRY: ${{ inputs.registry }}
+          MIRROR_REGISTRY: ${{ inputs.mirror_registry }}
           TAG: ${{ inputs.channel }}
         run: |
           # shellcheck disable=SC2086
@@ -360,7 +361,7 @@ jobs:
 
       - name: Install crane
         if: inputs.sign
-        uses: imjasonh/setup-crane@ # v0.4
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
 
       - name: Create manifest lists from the verified digests
         env:


### PR DESCRIPTION
Follow-up to #140. cosign was the last step still reading manifests from Docker Hub (1–2 GETs per image, ~70 per full channel against a 200/hour budget).

- `cosign sign` now runs against the GHCR mirror digest (no pull-rate limit); the signature artifact `<repo>:sha256-<digest>.sig` is then copied to Hub with `crane copy`. The signature is bound to the digest, which is identical on both registries, so `cosign verify docker.io/smartgic/<image>:<tag>` keeps working; Hub only sees a PUT and blob HEADs.
- Both steps retry 3× with 30 s pauses, so a transient registry error no longer aborts a channel half-way through its tags.
- `resolve` evaluates the bake file with `MIRROR_REGISTRY` set (consistency with the build/merge jobs).

Workflow-only change: `on-push` selects nothing on merge. Exercised by the next channel run (the hourly poll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)