### PR TITLE
Document the ghcr.io/openvoiceos mirror

### DIFF
--- a/docs/getting-started/docker/build.md
+++ b/docs/getting-started/docker/build.md
@@ -65,6 +65,7 @@ Defaults come from `scripts/bake.sh` and `docker-bake.hcl`:
 | `UV_PRERELEASE`   | `allow`                       | `uv pip` prerelease policy; use `if-necessary-or-explicit` for `testing`/`stable` (CI does) |
 | `CACHE_REPO`      | `ghcr.io/openvoiceos/ovos-docker-cache` | Registry build cache, read anonymously                |
 | `CACHE_TO`        | _(empty)_                     | `max` also exports the build cache (needs GHCR write access; CI does this) |
+| `MIRROR_REGISTRY` | _(empty)_                     | Second registry every image is also pushed to (CI: `ghcr.io/openvoiceos`); the pipeline reads manifests, labels and SBOMs from it |
 | `PLATFORMS`       | `linux/amd64,linux/arm64`      | Platforms to build                                            |
 | `TARGETS`         | `default`                     | Bake targets/groups                                           |
 | `PUSH`            | `true`                        | Push images to the registry                                   |

--- a/docs/getting-started/docker/images.md
+++ b/docs/getting-started/docker/images.md
@@ -2,10 +2,14 @@
 
 !!! tip "Pre-built images"
 
-    The compose bundles in `compose/` currently reference images hosted on
-    Docker Hub under `docker.io/smartgic`. Buildx Bake defaults to
-    `docker.io/smartgic`. If you publish to a different registry, update the
-    `image:` references in your compose files.
+    The compose bundles in `compose/` reference images hosted on Docker Hub
+    under `docker.io/smartgic`. The same images, with the same tags and
+    digests, are also published to `ghcr.io/openvoiceos` (for example
+    `ghcr.io/openvoiceos/ovos-core:alpha`), a mirror without pull-rate limits;
+    point the `image:` references of your compose files there if Docker Hub
+    rate-limits you. Buildx Bake defaults to `docker.io/smartgic`; if you
+    publish to a different registry, update the `image:` references in your
+    compose files.
 
 Open Voice OS is a sophisticated piece of software which has several [components](../../about/glossary/components.md). These components have been split into containers to provide better isolation and a [microservice](https://en.wikipedia.org/wiki/Microservices) approach.
 
@@ -70,8 +74,9 @@ All Python images share one base (`ovos-base`, Debian slim with Python 3.13,
 a virtual environment and a pinned [uv](https://github.com/astral-sh/uv));
 services needing sound add `ovos-sound-base`, skills add `ovos-skill-base`.
 Every channel tag is a multi-architecture manifest list (`amd64` + `arm64`)
-carrying an SBOM and SLSA provenance attestation, signed with cosign, and
-labelled with:
+carrying an SBOM and SLSA provenance attestation, signed with cosign, published
+to both `docker.io/smartgic` and `ghcr.io/openvoiceos` with identical digests,
+and labelled with:
 
 | Label                                 | Content                                                                      |
 | ------------------------------------- | ---------------------------------------------------------------------------- |


### PR DESCRIPTION
Images are now also published to `ghcr.io/openvoiceos` with identical digests (#140/#141); users hitting Docker Hub pull-rate limits can point compose at the mirror. Adds `MIRROR_REGISTRY` to the build variables table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)