### PR TITLE
[ci] Skill healthchecks, runtime smoke test per architecture, vulnerability scan

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -271,11 +271,21 @@ jobs:
           retention-days: 7
 
   verify:
-    name: Verify pushed images
+    name: Verify ${{ matrix.arch }}
     needs: [resolve, build]
     if: inputs.push
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -296,13 +306,14 @@ jobs:
           EXPECTED_REF: ${{ needs.resolve.outputs.ovos_releases_sha }}
           REGISTRY: ${{ inputs.registry }}
           MIRROR: ${{ inputs.mirror_registry }}
+          ARCH: ${{ matrix.arch }}
         run: |
           set +e   # report every bad image, then fail once at the end
           fail=0
           for target in $(echo "$TARGETS" | jq -r '.[]'); do
             # digests are identical on both registries; read from the mirror (no pull-rate limit)
             repo=$(echo "$IMAGES" | jq -r --arg t "$target" '.[$t]' | sed "s#^${REGISTRY}/#${MIRROR}/#")
-            for arch in amd64 arm64; do
+            for arch in "$ARCH"; do
               digest=$(jq -r --arg t "$target" '.[$t]["containerimage.digest"] // empty' "bake-meta-${arch}.json")
               if [ -z "$digest" ]; then echo "::error::${target}/${arch}: no digest in bake metadata"; fail=1; continue; fi
               ref="${repo}@${digest}"
@@ -325,6 +336,85 @@ jobs:
             done
           done
           exit $fail
+
+      - name: Smoke-run every image (from the mirror, this architecture)
+        env:
+          TARGETS: ${{ needs.resolve.outputs.targets }}
+          IMAGES: ${{ needs.resolve.outputs.images }}
+          REGISTRY: ${{ inputs.registry }}
+          MIRROR: ${{ inputs.mirror_registry }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set +e
+          fail=0
+          for target in $(echo "$TARGETS" | jq -r '.[]'); do
+            repo=$(echo "$IMAGES" | jq -r --arg t "$target" '.[$t]' | sed "s#^${REGISTRY}/#${MIRROR}/#")
+            ref="${repo}@$(jq -r --arg t "$target" '.[$t]["containerimage.digest"]' "bake-meta-${ARCH}.json")"
+            echo "::group::${target} (${ARCH})"
+            if ! docker pull -q "$ref" > /dev/null; then echo "::error::${target}: pull failed"; fail=1; echo "::endgroup::"; continue; fi
+            # the binary the image starts: first ENTRYPOINT element unless that is a shell/script, else first CMD element
+            bin=$(docker image inspect "$ref" --format '{{json .Config}}' | jq -r '
+              (.Entrypoint // []) as $e | (.Cmd // []) as $c
+              | if ($e | length) > 0 and ($e[0] | test("^(/bin/(ba)?sh|bash|sh)$") | not) and ($e[0] | test("\\.sh$") | not) then $e[0]
+                elif ($c | length) > 0 and ($c[0] | test("\\.sh$") | not) then $c[0] else "" end')
+            if docker run --rm -i -e SMOKE_BIN="$bin" --entrypoint /bin/bash "$ref" -s < scripts/ci/smoke.sh; then
+              echo "OK  ${target}"
+            else
+              echo "::error::${target} (${ARCH}): smoke test failed"; fail=1
+            fi
+            docker image rm -f "$ref" > /dev/null 2>&1 || true
+            echo "::endgroup::"
+          done
+          exit $fail
+
+  scan:
+    name: Vulnerability scan
+    needs: [resolve, build]
+    if: inputs.push
+    runs-on: ubuntu-24.04
+    continue-on-error: true   # informational for now; flip once the baseline is clean
+    steps:
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v6
+        with:
+          pattern: bake-meta-*
+          merge-multiple: true
+
+      - uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+
+      - name: Scan every image (amd64 copy on the mirror) for fixed CRITICAL/HIGH CVEs
+        env:
+          TARGETS: ${{ needs.resolve.outputs.targets }}
+          IMAGES: ${{ needs.resolve.outputs.images }}
+          REGISTRY: ${{ inputs.registry }}
+          MIRROR: ${{ inputs.mirror_registry }}
+          CHANNEL: ${{ inputs.channel }}
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ github.token }}
+        run: |
+          {
+            echo "### Vulnerability scan (\`${CHANNEL}\`, CRITICAL/HIGH with a fix available)"
+            echo
+            echo "| Image | Critical | High |"
+            echo "|---|---|---|"
+          } > scan.md
+          for target in $(echo "$TARGETS" | jq -r '.[]'); do
+            repo=$(echo "$IMAGES" | jq -r --arg t "$target" '.[$t]' | sed "s#^${REGISTRY}/#${MIRROR}/#")
+            ref="${repo}@$(jq -r --arg t "$target" '.[$t]["containerimage.digest"]' bake-meta-amd64.json)"
+            echo "::group::${target}"
+            trivy image --quiet --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed --exit-code 0 --format json --output "scan-${target}.json" "$ref" || echo "scan failed for ${target}"
+            c=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' "scan-${target}.json" 2>/dev/null || echo "?")
+            h=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' "scan-${target}.json" 2>/dev/null || echo "?")
+            jq -r '.Results[]?.Vulnerabilities[]? | "\(.Severity) \(.VulnerabilityID) \(.PkgName) \(.InstalledVersion) -> \(.FixedVersion)"' "scan-${target}.json" 2>/dev/null | sort -u | head -40
+            echo "| \`${target}\` | ${c} | ${h} |" >> scan.md
+            echo "::endgroup::"
+          done
+          cat scan.md >> "$GITHUB_STEP_SUMMARY"
 
   merge:
     name: Create channel manifests

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ manifest lists (see `.github/workflows/`):
 | `on-constraints.yml` | `repository_dispatch` from ovos-releases, hourly poll, manual | per channel, the images that contain a package whose `constraints-<channel>.txt` line changed since they were last built |
 | `pull-request.yml` | pull request | the affected targets, both architectures, no push |
 | `scheduled-rebuild.yml` | weekly | every image of a channel |
-| `build-images.yml` | called by the above, or manually | the reusable build: resolve → build per arch → verify → merge (+ cosign, `<channel>-YYYYMMDD` tag) |
+| `build-images.yml` | called by the above, or manually | the reusable build: resolve → build per arch → verify (labels, platform, runtime smoke test on each arch) + vulnerability scan → merge (+ cosign, `<channel>-YYYYMMDD` tag) |
 
 `scripts/affected.py` is the selector; the `build-state` branch records what each channel was built
 from (digest, ovos-releases commit, installed packages). Every image carries the label

--- a/scripts/ci/smoke.sh
+++ b/scripts/ci/smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Runtime smoke test, executed inside a freshly built image (docker run … --entrypoint /bin/bash -s < smoke.sh).
+# Proves the image can actually start: interpreter present, installed packages consistent, entrypoint
+# script parses, the service binary it execs exists, the readiness probe's dependency imports.
+set -euo pipefail
+
+if ! command -v python > /dev/null; then
+  echo "no python interpreter: not a Python image, nothing to check"
+  exit 0
+fi
+python -V
+pip check
+python -c "import websocket"   # ovos-hc (HEALTHCHECK) dependency
+
+for f in /usr/local/bin/entrypoint.sh /usr/local/bin/skill-entrypoint.sh; do
+  if [ -f "$f" ]; then
+    bash -n "$f"
+    echo "$f: syntax ok"
+    bin=$(grep -oE '^exec [A-Za-z0-9_./-]+' "$f" | tail -1 | awk '{print $2}' || true)
+    if [ -n "${bin:-}" ] && [ "$bin" != '"$@"' ]; then command -v "$bin" > /dev/null; echo "$f execs $bin: found"; fi
+  fi
+done
+
+if [ -n "${SKILL_ID:-}" ]; then
+  command -v ovos-skill-launcher > /dev/null
+  python -c "import ovos_workshop, ovos_bus_client"
+  echo "skill ${SKILL_ID}: launcher and workshop present"
+fi
+if [ -n "${SMOKE_BIN:-}" ]; then
+  command -v "$SMOKE_BIN" > /dev/null
+  echo "entrypoint binary ${SMOKE_BIN}: found"
+fi
+echo "smoke ok"

--- a/skills/skill-alerts/Dockerfile
+++ b/skills/skill-alerts/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-alerts -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-alerts.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-alerts.openvoiceos"]

--- a/skills/skill-camera/Dockerfile
+++ b/skills/skill-camera/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-camera -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-camera.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-camera.openvoiceos"]

--- a/skills/skill-date-time/Dockerfile
+++ b/skills/skill-date-time/Dockerfile
@@ -35,4 +35,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-date-time ovos-audio -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-date-time.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-date-time.openvoiceos"]

--- a/skills/skill-duckduckgo/Dockerfile
+++ b/skills/skill-duckduckgo/Dockerfile
@@ -34,4 +34,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-ddg -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-ddg.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-ddg.openvoiceos"]

--- a/skills/skill-easter-eggs/Dockerfile
+++ b/skills/skill-easter-eggs/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install skill-easter-eggs -c /tmp/constraints.txt
 
+ENV SKILL_ID="skill-easter-eggs.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "skill-easter-eggs.openvoiceos"]

--- a/skills/skill-fallback-unknown/Dockerfile
+++ b/skills/skill-fallback-unknown/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-fallback-unknown -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-fallback-unknown.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-fallback-unknown.openvoiceos"]

--- a/skills/skill-ggwave/Dockerfile
+++ b/skills/skill-ggwave/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-ggwave -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-ggwave.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-ggwave.openvoiceos"]

--- a/skills/skill-hello-world/Dockerfile
+++ b/skills/skill-hello-world/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-hello-world -c /tmp/constraints.txt
 
+ENV SKILL_ID="skill-ovos-hello-world.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "skill-ovos-hello-world.openvoiceos"]

--- a/skills/skill-homeassistant/Dockerfile
+++ b/skills/skill-homeassistant/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install skill-homeassistant -c /tmp/constraints.txt
 
+ENV SKILL_ID="skill-homeassistant.oscillatelabsllc"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "skill-homeassistant.oscillatelabsllc"]

--- a/skills/skill-homescreen/Dockerfile
+++ b/skills/skill-homescreen/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-homescreen -c /tmp/constraints.txt
 
+ENV SKILL_ID="skill-ovos-homescreen.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "skill-ovos-homescreen.openvoiceos"]

--- a/skills/skill-jokes/Dockerfile
+++ b/skills/skill-jokes/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-icanhazdadjokes -c /tmp/constraints.txt
 
+ENV SKILL_ID="skill-ovos-icanhazdadjokes.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "skill-ovos-icanhazdadjokes.openvoiceos"]

--- a/skills/skill-parrot/Dockerfile
+++ b/skills/skill-parrot/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-parrot -c /tmp/constraints.txt
 
+ENV SKILL_ID="skill-ovos-parrot.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "skill-ovos-parrot.openvoiceos"]

--- a/skills/skill-personal/Dockerfile
+++ b/skills/skill-personal/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-personal -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-personal.OpenVoiceOS"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-personal.OpenVoiceOS"]

--- a/skills/skill-randomness/Dockerfile
+++ b/skills/skill-randomness/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-randomness -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-randomness.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-randomness.openvoiceos"]

--- a/skills/skill-tunein/Dockerfile
+++ b/skills/skill-tunein/Dockerfile
@@ -34,4 +34,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install --prerelease=${UV_PRERELEASE} ovos-skill-tunein -c /tmp/constraints.txt
 
+ENV SKILL_ID="skill-ovos-tunein.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "skill-ovos-tunein.openvoiceos"]

--- a/skills/skill-volume/Dockerfile
+++ b/skills/skill-volume/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-volume -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-volume.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-volume.openvoiceos"]

--- a/skills/skill-weather/Dockerfile
+++ b/skills/skill-weather/Dockerfile
@@ -48,4 +48,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 USER "$USER"
 
+ENV SKILL_ID="ovos-skill-weather.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-weather.openvoiceos"]

--- a/skills/skill-wikihow/Dockerfile
+++ b/skills/skill-wikihow/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-wikihow -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-wikihow.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-wikihow.openvoiceos"]

--- a/skills/skill-wikipedia/Dockerfile
+++ b/skills/skill-wikipedia/Dockerfile
@@ -34,4 +34,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-wikipedia -c /tmp/constraints.txt
 
+ENV SKILL_ID="skill-ovos-wikipedia.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "skill-ovos-wikipedia.openvoiceos"]

--- a/skills/skill-wolfie/Dockerfile
+++ b/skills/skill-wolfie/Dockerfile
@@ -34,4 +34,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-wolfie -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-wolfie.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-wolfie.openvoiceos"]

--- a/skills/skill-wordnet/Dockerfile
+++ b/skills/skill-wordnet/Dockerfile
@@ -33,4 +33,11 @@ ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${O
 RUN --mount=type=cache,target=/home/ovos/.cache/uv,uid=1000,gid=1000,sharing=locked \
     uv pip install ovos-skill-wordnet -c /tmp/constraints.txt
 
+ENV SKILL_ID="ovos-skill-wordnet.openvoiceos"
+
+# A loaded skill answers mycroft.<skill_id>.is_ready (ovos-workshop ProcessStatus); the start period
+# covers waiting for ovos-core to become ready before the skill loads.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=180s \
+  CMD ovos-hc -s "$SKILL_ID" || exit 1
+
 CMD ["ovos-skill-launcher", "ovos-skill-wordnet.openvoiceos"]


### PR DESCRIPTION
Three of the four remaining review items (the fourth — image-size dive — is a report, see below).

## Skill healthchecks (21 Dockerfiles)
`ovos-core` does not track standalone skills (`TODO handle external skills` in `skill_manager.py`), but every `OVOSSkill` creates a `ProcessStatus(self.skill_id, …)`, which answers `mycroft.<skill_id>.is_ready`. So each skill image now sets `ENV SKILL_ID=<its id>` and `HEALTHCHECK … ovos-hc -s "$SKILL_ID"` — the probe already in `ovos-base`, ~300 ms. `start-period` 180 s covers waiting for `ovos-core` to be ready before the skill loads. A skill that failed to load never binds the status handler → unhealthy, which is the right signal.

## Runtime smoke test (`verify`, now per architecture)
`verify` runs on `ubuntu-24.04` and `ubuntu-24.04-arm`, pulls every image **from the GHCR mirror** (no Hub budget) and runs `scripts/ci/smoke.sh` inside it: `python -V`, `pip check` (dependency graph consistent), `bash -n` on the entrypoint script, the binary the entrypoint `exec`s (or the image's ENTRYPOINT/CMD binary) exists on `PATH`, `import websocket` (probe dependency), and for skills `ovos-skill-launcher` + `import ovos_workshop`. Images without Python (GUIs) pass trivially. `merge` still waits for `verify`, so a broken image never moves a tag.

## Vulnerability scan (`scan` job)
Trivy (`aquasecurity/setup-trivy`, pinned) on the amd64 copy of every image from the mirror, `CRITICAL,HIGH`, `--ignore-unfixed`, table in the run summary; `continue-on-error` so it is informational until the baseline is clean.

## Image-size dive (no change, by the numbers)
- `ovos-audio` (410 MB): its Python wheels are ~84 MB; the rest is Debian's **libmpv** dependency chain — `libllvm19` 124 MB, `mesa-libgallium` 41 MB, `libz3` 27 MB, `libplacebo`, `xkb-data` — and `libmpv2` has the *same* 295 MB closure as `mpv` on trixie. Only dropping the mpv audio backend would remove it.
- `sound-base`: `libasound2-plugins` (the ALSA→Pulse bridge this design relies on) pulls the codec stack (117 MB incl. libavcodec/x265/rsvg); `music123` pulls the GNAT runtime (5 MB).
- `listener` (331 MB): scipy 35 MB, `speechrecognition` 33 MB (bundles flac for every platform), onnxruntime 23 MB, numpy 17 MB, vosk 14 MB — all real dependencies.
- GUI images left out as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added container health monitoring for supported skill images, including startup grace periods and readiness checks.
  - Added runtime smoke testing across AMD64 and ARM64 images.
  - Added vulnerability scanning for built images, with high- and critical-severity findings summarized during builds.

- **Documentation**
  - Updated automation documentation to describe architecture verification, runtime checks, and vulnerability scanning before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->