### PR TITLE
[ci] Dry runs get their own concurrency group

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -202,7 +202,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 240
     concurrency:
-      group: build-images-${{ inputs.channel }}-${{ matrix.arch }}
+      # publishing runs of one channel are serialized per architecture; dry runs (pull requests)
+      # get a group of their own so they never displace or wait for a publishing run
+      group: ${{ inputs.push && format('build-images-{0}-{1}', inputs.channel, matrix.arch) || format('dry-run-{0}-{1}', github.run_id, matrix.arch) }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Pull-request (dry-run) builds shared the `build-images-<channel>-<arch>` concurrency group with publishing runs; GitHub keeps one running + one pending per group, so #149's PR build was cancelled by the alpha bootstrap. Dry runs now use `dry-run-<run id>-<arch>`; publishing runs keep their per-channel/arch serialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)