### PR TITLE
[bake] Stop building skill-homescreen

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -47,7 +47,6 @@ variable "SKILLS" {
     "ggwave",
     "hello-world",
     "homeassistant",
-    "homescreen",
     "jokes",
     "parrot",
     "personal",


### PR DESCRIPTION
The homescreen skill only serves the GUI, which is no longer built (#149). Its current alpha also conflicts with `ovos-core` (`ovos-workshop<9` vs `>=9.3.11a1`) and was already held back by verification. Removed from the `SKILLS` list; the Dockerfile stays in `skills/` for now, and the last published tags remain on the registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)