### PR TITLE
fix(ci): GHCR mirror sub-namespace, cosign v2 pin, universal ovos-hc

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,7 +16,7 @@ name: Build images
 #
 # Docker Hub (the registry users pull from) counts every manifest GET against a small hourly
 # budget, so the pipeline never reads from it: every image is also pushed to a GHCR mirror
-# (ghcr.io/openvoiceos, no pull-rate limit) and verify, manifest creation, inspection and SBOM
+# (ghcr.io/openvoiceos/ovos-docker, no pull-rate limit) and verify, manifest creation, inspection and SBOM
 # reads use the mirror. Hub only receives pushes and the cosign signatures. The build cache lives
 # on GHCR as well.
 
@@ -45,7 +45,7 @@ on:
       mirror_registry:
         description: Second registry every image is pushed to; the pipeline reads from it (no pull-rate limit)
         type: string
-        default: ghcr.io/openvoiceos
+        default: ghcr.io/openvoiceos/ovos-docker
       uv_prerelease:
         description: "uv --prerelease mode; auto = allow for alpha, if-necessary-or-explicit for testing/stable"
         type: string
@@ -90,7 +90,7 @@ on:
       mirror_registry:
         description: Second registry the pipeline pushes to and reads from
         type: string
-        default: ghcr.io/openvoiceos
+        default: ghcr.io/openvoiceos/ovos-docker
       uv_prerelease:
         description: "uv --prerelease mode (auto = allow for alpha, if-necessary-or-explicit otherwise)"
         type: string

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The images run on Docker or on Podman.
 - Podman: `podman pull docker.io/smartgic/ovos-core:alpha`
 
 The same images, with the same tags and digests, are available from the mirror
-`ghcr.io/openvoiceos`. Use the mirror if Docker Hub limits your pulls.
+`ghcr.io/openvoiceos/ovos-docker`. Use the mirror if Docker Hub limits your pulls.
 
 ### Tags
 
@@ -85,7 +85,7 @@ Note: `--load` forces `linux/amd64`, because Docker cannot load multi-arch manif
 `docker-bake.hcl` and `scripts/bake.sh` define the defaults:
 
 - `REGISTRY` (default `docker.io/smartgic`)
-- `MIRROR_REGISTRY` (default empty; CI uses `ghcr.io/openvoiceos`): a second registry each image is also pushed to
+- `MIRROR_REGISTRY` (default empty; CI uses `ghcr.io/openvoiceos/ovos-docker`): a second registry each image is also pushed to
 - `TAG` and `VERSION` (default `alpha`)
 - `LATEST_TAG` (default `latest`; applied only when `TAG=stable`)
 - `CHANNEL` (default `alpha`): selects the constraints file

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -30,7 +30,7 @@ variable "OVOS_RELEASES_REF" { default = "main" }
 variable "CACHE_REPO" { default = "ghcr.io/openvoiceos/ovos-docker-cache" }
 variable "CACHE_TO"   { default = "" }
 
-# Optional second registry every image is also pushed to (CI uses ghcr.io/openvoiceos). The pipeline
+# Optional second registry every image is also pushed to (CI uses ghcr.io/openvoiceos/ovos-docker). The pipeline
 # reads manifests, labels and SBOMs from there, which has no pull-rate limit; users keep pulling
 # from REGISTRY. Empty = single registry (local builds).
 variable "MIRROR_REGISTRY" { default = "" }


### PR DESCRIPTION
## Why

Three defects found by the first full-channel runs:

1. **Mirror package collision** ([run 33330583687](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33330583687)): `ghcr.io/openvoiceos/ovos-messagebus` is owned by the OpenVoiceOS/ovos-messagebus repository (its own CI created it first), so pushes from this repository are denied and every push-mode run fails. Any upstream repo can claim `ovos-<name>` the same way tomorrow.
2. **No image is signed on Docker Hub** ([run 33329260017](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33329260017)): cosign v3 stores signatures only as OCI referrer bundles — even with `--registry-referrers-mode=legacy` — so the `sha256-<digest>.sig` tag never exists on the mirror and every `crane copy` to Hub 404s (3 retries × 28 images ≈ the 46-minute merge job).
3. **base, sound-base and plugin-ggwave fail the smoke test**: `ovos-hc` needs `websocket`, which only images that happen to install a bus client had. Bonus: the failure annotation grepped for "requirement" and reported pip check's *"No broken requirements found."* as the reason.

## What

- Mirror images move under `ghcr.io/openvoiceos/ovos-docker/<image>` — a sub-namespaced package is always linked to the repo whose workflow created it, so no cross-repo grants are ever needed (the build cache already follows this rule). Only the `mirror_registry` defaults and docs change. The old `ghcr.io/openvoiceos/ovos-*` mirror packages can be deleted from package settings at leisure.
- `cosign-installer` pins `cosign-release: v2.6.5` (tag storage restored; the legacy-mode flag stays for GHCR's OCI-1.1 support).
- `websocket-client` ships in the base venv, so `ovos-hc` works in every image and the smoke test's `import websocket` is valid everywhere.
- The smoke failure annotation reports the failing command's actual output.

## After merge

- tag `v2.0.1` (hivemind-docker's workflows pin `build-images.yml@v2.0.1`)
- dispatch `on-constraints`: testing/stable have no recorded state, so they rebuild fully against the new mirror; alpha converges (and gets re-signed) from its bootstrap state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)