### PR TITLE
fix(ci): pin cosign v2, ship websocket-client in base, truthful smoke reasons

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -368,7 +368,9 @@ jobs:
             if [ "$rc" -eq 0 ]; then
               echo "OK  ${target}"; echo "${target}" >> passed.txt
             else
-              reason=$(grep -aiE 'requirement|No module|not found|Error' smoke.log | head -1 | cut -c1-160)
+              # the failing command's output is at the end (set -e); pip check's
+            # "No broken requirements found." must never be reported as the reason
+            reason=$(grep -avE '^\s*$' smoke.log | grep -av 'No broken requirements' | tail -2 | tr '\n' ' ' | cut -c1-200)
               echo "::error::${target} (${ARCH}): smoke test failed: ${reason}"; echo "${target} smoke: ${reason}" >> failed.txt
             fi
             docker image rm -f "$ref" > /dev/null 2>&1 || true
@@ -471,6 +473,11 @@ jobs:
       - name: Install cosign
         if: inputs.sign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # v3 stores signatures only as OCI referrer bundles, even with
+          # --registry-referrers-mode=legacy, so the sha256-<digest>.sig tag the
+          # signature copy to Docker Hub relies on is never created. v2 keeps tag storage.
+          cosign-release: 'v2.6.5'
 
       - name: Install crane
         if: inputs.sign

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -66,6 +66,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # The venv keeps the pip bundled with the (digest-pinned) Python image. setuptools is still needed at
 # runtime by packages using pkg_resources; pinned like ovos-installer does (setuptools<82).
+# websocket-client makes ovos-hc (the HEALTHCHECK of every service image) work everywhere,
+# including images that install no bus client of their own.
 # Bytecode is compiled at install time (UV_COMPILE_BYTECODE, and compileall after pip installs) so
 # services start fast on small devices; PYTHONDONTWRITEBYTECODE keeps the running container from
 # writing .pyc files into its layer.
@@ -74,7 +76,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
  && useradd --no-log-init --uid "$USER_UID" --gid "$USER_GID" -m -c "Open Voice OS user" "$USER" \
  && python -m venv "/home/${USER}/.venv" \
  && source "/home/${USER}/.venv/bin/activate" \
- && uv pip install "setuptools<82" \
+ && uv pip install "setuptools<82" websocket-client \
  && mkdir -p "/home/${USER}"/.{config,cache,local/{state,share}}/{mycroft,OpenVoiceOS} \
  && chown "${USER}:${USER}" -R "/home/${USER}"
 


### PR DESCRIPTION
## Why

These three fixes were amended onto #157's branch **after** it was merged, so they never reached dev — [run 33331293773](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33331293773) shows all three symptoms: cosign v3 signed via OCI referrer bundles (the mirror has a bare `sha256-<digest>` referrers tag, no `.sig`, so every signature copy to Hub 404s), `base`/`sound-base` failed the smoke test on `import websocket`, and the failure annotation reported pip check's *"No broken requirements found."*.

## What

- `cosign-installer` pins `cosign-release: v2.6.5` — v2 keeps `sha256-<digest>.sig` tag storage that the crane copy to Docker Hub relies on
- `websocket-client` ships in the base venv, so `ovos-hc` (every service image's HEALTHCHECK) and the smoke test's import work in every image
- smoke failure annotations report the failing command's actual output

## After merge

Tagged **v2.0.2**; the merge triggers a full republish (base changed), which re-signs all channels properly. hivemind-docker and ovos-installer pins get bumped to v2.0.2. v2.0.1's release notes are corrected to describe only the mirror fix it actually contains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)