### PR TITLE
fix(ci): hold cosign at v2 — Renovate re-bumped it to v3 right after the pin

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -477,7 +477,7 @@ jobs:
           # v3 stores signatures only as OCI referrer bundles, even with
           # --registry-referrers-mode=legacy, so the sha256-<digest>.sig tag the
           # signature copy to Docker Hub relies on is never created. v2 keeps tag storage.
-          cosign-release: 'v3.1.3'
+          cosign-release: 'v2.6.5'
 
       - name: Install crane
         if: inputs.sign

--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,20 @@
   "packageRules": [
     {
       "description": "Python 3.13 is the newest version OpenVoiceOS/ovos-releases tests (build_tests.yml); bump this when 3.14 is added there",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["python"],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "python"
+      ],
       "allowedVersions": "<3.14"
+    },
+    {
+      "matchPackageNames": [
+        "sigstore/cosign"
+      ],
+      "allowedVersions": "<3.0.0",
+      "description": "cosign v3 stores signatures only as OCI referrer bundles (no sha256-<digest>.sig tag), which breaks the signature copy to Docker Hub"
     }
   ]
 }


### PR DESCRIPTION
#159 (Renovate) updated `cosign-release` back to v3 minutes after #158 pinned v2.6.5 — Renovate tracks that field as a dependency, so without a rule it will keep re-opening the bump. cosign v3 stores signatures only as OCI referrer bundles (no `sha256-<digest>.sig` tag), which breaks the signature copy to Docker Hub.

The pin returns to `v2.6.5` and `renovate.json` gains a `sigstore/cosign` `allowedVersions: <3.0.0` rule (with the reason in its description) so patch/minor v2 updates still flow but v3 stays out until the signature flow moves to referrer bundles deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)