### PR TITLE
fix(plugin-ggwave): hold the plugin below 1.0.0 to keep the standalone listener

### DIFF
--- a/plugin-ggwave/Dockerfile
+++ b/plugin-ggwave/Dockerfile
@@ -43,7 +43,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update \
  && apt-get install -o Dpkg::Options::="--force-confold" -y --no-install-recommends --no-install-suggests portaudio19-dev build-essential python3-dev \
  && uv pip install -f 'https://whl.smartgic.io/' ggwave \
- && uv pip install --prerelease=${UV_PRERELEASE} ovos-audio-transformer-plugin-ggwave padacioso -c /tmp/constraints.txt \
+ # 1.0.0a1 removed the ovos-ggwave-listener console script (the plugin now only loads
+ # inside ovos-audio as an opm.transformer.audio plugin); this image exists to run the
+ # standalone listener, and the package is not in the constraints file, so hold it back.
+ && uv pip install --prerelease=${UV_PRERELEASE} "ovos-audio-transformer-plugin-ggwave<1.0.0" padacioso -c /tmp/constraints.txt \
  && apt-get --purge remove -y portaudio19-dev build-essential python3-dev \
  && apt-get --purge autoremove -y \
  && rm -rf /var/log/{apt,dpkg.log} /tmp/* /var/tmp/*


### PR DESCRIPTION
The alpha rebuild ([run 33336582414](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33336582414)) published and signed every image except `plugin-ggwave`: its smoke test found no `ovos-ggwave-listener` binary. `ovos-audio-transformer-plugin-ggwave` **1.0.0a1** (published within the hour, and not part of the ovos-releases constraints) removed the `console_scripts` entry — the plugin now only loads inside `ovos-audio` as an `opm.transformer.audio` plugin ([0.0.6a8 vs 1.0.0a1 entry points](https://pypi.org/project/ovos-audio-transformer-plugin-ggwave/)).

This image exists precisely to run the standalone listener, so it holds the package `<1.0.0` with the reason in a comment. Follow-up worth deciding separately: with 1.x the transformer runs inside the `audio` container, so this standalone image may be a candidate for retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)