### PR TITLE
fix(listener): plugin extras become channel-dependent so stable builds

### DIFF
--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -50,6 +50,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update \
  && apt-get install -o Dpkg::Options::="--force-confold" -y --no-install-recommends --no-install-suggests libatomic1 portaudio19-dev libpulse-dev build-essential python3-dev \
  && uv pip install --prerelease=${UV_PRERELEASE} -r /tmp/requirements.txt -c /tmp/constraints.txt \
+ # Plugin extras, richest set the channel can resolve: [onnx] needs ovos-plugin-manager>=2
+ # (alpha/testing); the stable constraints are still on opm<0.10, where only [extras]
+ # resolves. Whatever is skipped can be added at runtime via listener.list.
+ && (uv pip install --prerelease=${UV_PRERELEASE} -c /tmp/constraints.txt "ovos-dinkum-listener[extras,onnx]" \
+     || uv pip install --prerelease=${UV_PRERELEASE} -c /tmp/constraints.txt "ovos-dinkum-listener[extras]" \
+     || echo "plugin extras unavailable on this channel; add plugins via listener.list") \
  && mkdir -p "/home/${USER}/.local/share/vosk" "/home/${USER}/.local/share/precise-lite" "/home/${USER}/.local/share/mycroft/listener" \
  && chown "${USER}:${USER}" -R "/home/${USER}" \
  && apt-get --purge remove -y portaudio19-dev libpulse-dev build-essential python3-dev \

--- a/listener/files/requirements.txt
+++ b/listener/files/requirements.txt
@@ -1,1 +1,4 @@
-ovos-dinkum-listener[extras,linux,onnx]
+# The guaranteed-everywhere base: dinkum + the ALSA microphone. The plugin extras
+# (STT/VAD/wake word) are channel-dependent and installed by the Dockerfile where
+# the channel's constraints allow them.
+ovos-dinkum-listener[linux]


### PR DESCRIPTION
The stable rebuild ([run 33339443282](https://github.com/OpenVoiceOS/ovos-docker/actions/runs/33339443282)) failed resolving the listener, and one failing target takes the whole channel's bake with it: `constraints-stable` still pins `ovos-plugin-manager<0.10`, while the `[onnx]` extra's `ovos-ww-plugin-openwakeword` needs `opm>=2.1` in every usable version — and the tflite-based wake-word plugins the stable set does pin have no cp313 wheels. The stable ecosystem simply predates Python 3.13 here.

Same pattern as hivemind-docker's satellite: `requirements.txt` keeps the guaranteed base (`ovos-dinkum-listener[linux]`), and the Dockerfile layers the richest extras set the channel can resolve — `[extras,onnx]` on alpha/testing (unchanged content), `[extras]` on stable (STT/VAD/mic/vosk, verified locally against `constraints-stable`), bare base as the last resort. The entrypoint's `listener.list` remains the runtime escape hatch either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)