### PR TITLE
fix(listener): ship every VAD plugin the configuration can select

### DIFF
--- a/listener/files/requirements.txt
+++ b/listener/files/requirements.txt
@@ -2,3 +2,9 @@
 # (STT/VAD/wake word) are channel-dependent and installed by the Dockerfile where
 # the channel's constraints allow them.
 ovos-dinkum-listener[linux]
+# Every VAD plugin the configuration can name: silero arrives with [extras] for capable
+# CPUs, webrtcvad is what ovos-installer selects for the rest, and noise is the fallback
+# OVOSVADFactory retries with. A configured plugin the image cannot load kills the
+# listener at startup, so all three have to be here.
+ovos-vad-plugin-webrtcvad
+ovos-vad-plugin-noise


### PR DESCRIPTION
## Symptom (from a running deployment)

```
WARNING - Could not find the plugin PluginTypes.VAD.ovos-vad-plugin-webrtcvad
ERROR - VAD plugin ovos-vad-plugin-webrtcvad could not be loaded!
INFO - Attempting to load fallback plugin instead: ovos-vad-plugin-noise
WARNING - Could not find the plugin PluginTypes.VAD.ovos-vad-plugin-noise
```

…and the listener container exits.

## Cause

The image installs `ovos-dinkum-listener[extras,onnx]`, and with 0.9.0a1 that extra provides **only** `ovos-vad-plugin-silero` — `webrtcvad` moved to the `tests` extra and `ovos-vad-plugin-noise` was dropped entirely (0.4.1 still had it).

Meanwhile ovos-installer writes `"VAD": {"module": …}` into `mycroft.conf`, choosing **silero** when the host reports AVX2/SIMD and **webrtcvad** otherwise. On a host in the second group the configured plugin is not in the image at all, and neither is the fallback `OVOSVADFactory` retries with — so a VAD miss is fatal rather than degrading.

## Fix

The listener now installs both missing plugins explicitly, so every module the configuration can name exists in the image:

- `ovos-vad-plugin-webrtcvad` — what the installer selects without AVX2 (its C extension builds inside the existing toolchain window and `pkg_resources` is satisfied by the base image's `setuptools<82`)
- `ovos-vad-plugin-noise` — pure-Python, the documented fallback

Verified both resolve against `constraints-alpha` and `constraints-stable` alongside `ovos-dinkum-listener[extras,linux]`. The equivalent gap in hivemind-docker's satellite is fixed in a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved listener startup reliability by including required voice activity detection components.
  * Prevented startup failures when configured audio detection options are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->