### PR TITLE
docs: drop the retired plugin-ggwave image

### DIFF
--- a/docs/about/glossary/components.md
+++ b/docs/about/glossary/components.md
@@ -66,11 +66,6 @@ The message bus service provides a websocket where all internal events travel, y
 
     The bus is considered as an internal and private websocket, external clients should not connect directly to it. Please check [HiveMind](terms.md#hivemind) for more information. For more details, go to the [System Hardening](../../getting-started/docker/security/hardening.md) section.
 
-## :material-waveform: ovos-plugin-ggwave
-
-Audio data transfer plugin container based on ggwave. It enables ultrasonic
-communication features used by compatible skills.
-
 ## :material-memory: ovos-phal
 
 Plugin-based Hardware Abstraction Layer is a wrapper for system-level abstraction. Based on the environment, either through known configuration or via fingerprinting, only specific plugins load to interface with the system and specific hardware.

--- a/docs/getting-started/docker/build.md
+++ b/docs/getting-started/docker/build.md
@@ -36,7 +36,7 @@ REGISTRY=docker.io/smartgic TAG=alpha CHANNEL=alpha ./scripts/bake.sh
 | ------------ | ----------------------------------------------------------------------------------------- |
 | `default`    | All images defined in `docker-bake.hcl`                                                    |
 | `stack`      | `base`, `sound-base`, `core`                                                              |
-| `services`   | `audio`, `cli`, `core`, `gui-websocket`, `listener`, `messagebus`, `phal`, `phal-admin`, `plugin-ggwave` |
+| `services`   | `audio`, `cli`, `core`, `gui-websocket`, `listener`, `messagebus`, `phal`, `phal-admin` |
 | `skills`     | `skill-base` plus one `skill-<name>` image per entry of the `SKILLS` list in `docker-bake.hcl` |
 
 Adding a skill is one entry in `SKILLS` plus a `skills/skill-<name>/Dockerfile`;

--- a/docs/getting-started/docker/images.md
+++ b/docs/getting-started/docker/images.md
@@ -45,7 +45,6 @@ The list below is not exhaustive and doesn't mention anything about skill contai
 | `ovos_core`          | [Read more about ovos-core](../../about/glossary/components.md#ovos-core)                     |
 | `ovos_cli`           | [Read more about ovos-cli](../../about/glossary/components.md#ovos-cli)                       |
 | `ovos_gui_websocket` | [Read more about ovos-gui-websocket](../../about/glossary/components.md#ovos-gui-websocket)  |
-| `ovos_plugin_ggwave` | [Read more about ovos-plugin-ggwave](../../about/glossary/components.md#ovos-plugin-ggwave)   |
 
 ## Tags
 

--- a/docs/getting-started/docker/installation/basic.md
+++ b/docs/getting-started/docker/installation/basic.md
@@ -78,7 +78,6 @@ At this point of the installation, here are the containers that should be up and
     a4db13a597a4   docker.io/smartgic/ovos-phal-admin:alpha     "/bin/bash /usr/loca…"   25 hours ago   Up 8 hours                       ovos_phal_admin
     d157740c9965   docker.io/smartgic/ovos-messagebus:alpha     "/bin/bash -c ovos-m…"   25 hours ago   Up 8 hours (healthy)             ovos_messagebus
     6e3536dcfae5   docker.io/smartgic/ovos-cli:alpha            "sleep infinity"         25 hours ago   Up 8 hours                       ovos_cli
-    12c2b6d4f6e7   docker.io/smartgic/ovos-plugin-ggwave:alpha  "sleep infinity"         25 hours ago   Up 8 hours                       ovos_plugin_ggwave
     ```
 
 === "Podman"
@@ -93,5 +92,4 @@ At this point of the installation, here are the containers that should be up and
     a4db13a597a4   docker.io/smartgic/ovos-phal-admin:alpha     "/bin/bash /usr/loca…"   25 hours ago   Up 8 hours                       ovos_phal_admin
     d157740c9965   docker.io/smartgic/ovos-messagebus:alpha     "/bin/bash -c ovos-m…"   25 hours ago   Up 8 hours (healthy)             ovos_messagebus
     6e3536dcfae5   docker.io/smartgic/ovos-cli:alpha            "sleep infinity"         25 hours ago   Up 8 hours                       ovos_cli
-    12c2b6d4f6e7   docker.io/smartgic/ovos-plugin-ggwave:alpha  "sleep infinity"         25 hours ago   Up 8 hours                       ovos_plugin_ggwave
     ```

--- a/docs/getting-started/docker/installation/skills.md
+++ b/docs/getting-started/docker/installation/skills.md
@@ -174,7 +174,6 @@ At this point of the installation, here are the containers that should be up and
     98110d0b4b97   docker.io/smartgic/ovos-phal-admin:alpha        "/bin/bash /usr/loca…"   25 hours ago   Up 8 hours                       ovos_phal_admin
     8a179e135a6f   docker.io/smartgic/ovos-messagebus:alpha        "/bin/bash -c ovos-m…"   25 hours ago   Up 8 hours (healthy)             ovos_messagebus
     9c5fbad6c50d   docker.io/smartgic/ovos-cli:alpha               "sleep infinity"         25 hours ago   Up 8 hours                       ovos_cli
-    f0a451e1b14d   docker.io/smartgic/ovos-plugin-ggwave:alpha     "sleep infinity"         25 hours ago   Up 8 hours                       ovos_plugin_ggwave
     ```
 
 === "Podman"
@@ -200,5 +199,4 @@ At this point of the installation, here are the containers that should be up and
     98110d0b4b97   docker.io/smartgic/ovos-phal-admin:alpha        "/bin/bash /usr/loca…"   25 hours ago   Up 8 hours                       ovos_phal_admin
     8a179e135a6f   docker.io/smartgic/ovos-messagebus:alpha        "/bin/bash -c ovos-m…"   25 hours ago   Up 8 hours (healthy)             ovos_messagebus
     9c5fbad6c50d   docker.io/smartgic/ovos-cli:alpha               "sleep infinity"         25 hours ago   Up 8 hours                       ovos_cli
-    f0a451e1b14d   docker.io/smartgic/ovos-plugin-ggwave:alpha     "sleep infinity"         25 hours ago   Up 8 hours                       ovos_plugin_ggwave
     ```

--- a/docs/getting-started/docker/security/hardening.md
+++ b/docs/getting-started/docker/security/hardening.md
@@ -14,9 +14,8 @@ for every deployment:
 | `security_opt: no-new-privileges:true`   | same services                                                                                  | no privilege escalation through setuid binaries                     |
 | non-root user (`ovos`, UID 1000)         | all images except `ovos_phal_admin`                                                            | processes never run as root                                         |
 
-`ovos_phal` and `ovos_phal_admin` (hardware access) and `ovos_listener`,
-`ovos_audio` and `ovos_plugin_ggwave` (sound devices) keep the device access
-they need.
+`ovos_phal` and `ovos_phal_admin` (hardware access) and `ovos_listener`
+and `ovos_audio` (sound devices) keep the device access they need.
 
 ## AppArmor
 
@@ -91,7 +90,6 @@ docker container list --quiet --all --filter "name=ovos" | xargs docker inspect 
 /ovos_phal_admin: AppArmorProfile=unconfined
 /ovos_messagebus: AppArmorProfile=docker-default
 /ovos_cli: AppArmorProfile=docker-default
-/ovos_plugin_ggwave: AppArmorProfile=docker-default
 ```
 
 !!! note "`ovos_phal_admin` container is not confined"

--- a/docs/getting-started/docker/security/hivemind.md
+++ b/docs/getting-started/docker/security/hivemind.md
@@ -111,7 +111,6 @@ At this point of the installation, here are the containers that should be up and
     a4db13a597a4   docker.io/smartgic/ovos-phal-admin:alpha        "/bin/bash /usr/loca…"   25 hours ago     Up 8 hours                       ovos_phal_admin
     d157740c9965   docker.io/smartgic/ovos-messagebus:alpha        "/bin/bash -c ovos-m…"   25 hours ago     Up 8 hours (healthy)             ovos_messagebus
     6e3536dcfae5   docker.io/smartgic/ovos-cli:alpha               "sleep infinity"         25 hours ago     Up 8 hours                       ovos_cli
-    12c2b6d4f6e7   docker.io/smartgic/ovos-plugin-ggwave:alpha     "sleep infinity"         25 hours ago     Up 8 hours                       ovos_plugin_ggwave
     ```
 
 === "Podman"
@@ -139,5 +138,4 @@ At this point of the installation, here are the containers that should be up and
     a4db13a597a4   docker.io/smartgic/ovos-phal-admin:alpha        "/bin/bash /usr/loca…"   25 hours ago     Up 8 hours                       ovos_phal_admin
     d157740c9965   docker.io/smartgic/ovos-messagebus:alpha        "/bin/bash -c ovos-m…"   25 hours ago     Up 8 hours (healthy)             ovos_messagebus
     6e3536dcfae5   docker.io/smartgic/ovos-cli:alpha               "sleep infinity"         25 hours ago     Up 8 hours                       ovos_cli
-    12c2b6d4f6e7   docker.io/smartgic/ovos-plugin-ggwave:alpha     "sleep infinity"         25 hours ago   Up 8 hours                       ovos_plugin_ggwave
     ```


### PR DESCRIPTION
Documentation half of #165, which retires the standalone `plugin-ggwave` image per the decision in #163.

Removed from:

- the component glossary (its own section)
- the image table in `images.md` and the `services` group listing in `build.md`
- the hardening page — both the device-access sentence and the AppArmor sample output
- the sample `docker ps` output in `basic.md`, `skills.md` and `security/hivemind.md`

`skill-ggwave` is a different image, still built and still documented — left untouched everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)