### PR TITLE
cli: ship a terminal client for talking to OVOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,30 @@ the audio setup, and the device mapping.
 
 - Base layers: `ovos-base`, `ovos-sound-base`, `ovos-skill-base`
 - Core runtime: `ovos-core`
-- Services: `ovos-audio`, `ovos-cli`, `ovos-listener`, `ovos-messagebus`, `ovos-phal`,
-  `ovos-phal-admin`, `ovos-gui-websocket`
+- Services: `ovos-audio`, `ovos-cli` (also a terminal client, see below), `ovos-listener`,
+  `ovos-messagebus`, `ovos-phal`, `ovos-phal-admin`, `ovos-gui-websocket`
 - Skills: one image per entry of the `SKILLS` list in `docker-bake.hcl`
 
 All Python images share `ovos-base` (Debian slim, Python 3.13, a virtual environment, and a
 pinned [uv](https://github.com/astral-sh/uv)). Each image has a `HEALTHCHECK`, an SBOM, a
 provenance attestation, and a cosign signature.
+
+## Talking to OVOS from a terminal
+
+The `ovos-cli` image ships [ovos-tui-client](https://github.com/andlo/ovos-tui-client),
+a split-pane terminal for talking to OVOS without a microphone: type what you would have
+said, read the reply, and watch which skill answered.
+
+```shell
+docker exec -it ovos_cli ovos-tui
+```
+
+No flags needed. The container runs with `network_mode: host`, so it reaches the
+messagebus on `127.0.0.1:8181`, and the config and state volumes are already mounted
+where the client looks for them.
+
+`-it` is required: unlike the other services this is an interactive program and needs a
+terminal attached.
 
 ## Run images
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -54,6 +54,9 @@ USER "$USER"
 
 ENV EDITOR=vim
 ENV TERM=linux
+# ovos-tui renders in 16 colours without this and in full colour with it.
+# TERM stays "linux" because vim and nano are used in here too.
+ENV COLORTERM=truecolor
 
 ENTRYPOINT ["sleep", "infinity"]
 

--- a/cli/files/requirements.txt
+++ b/cli/files/requirements.txt
@@ -1,3 +1,4 @@
 ovos-config
 git+https://github.com/OpenVoiceOS/ovos-docs-viewer.git
 ovos-plugin-manager
+ovos-tui-client


### PR DESCRIPTION
The `ovos-cli` image is where you go to poke at a running install, but it had nothing to actually *talk* to OVOS with — `ovos-config`, `ovos-plugin-manager` and the docs viewer, all inspection tools. [ovos-tui-client](https://github.com/andlo/ovos-tui-client) fills that gap: a split-pane terminal where you type what you would have said, read the reply, and watch which skill answered and why, with no microphone involved.

It is also the maintained replacement for `ovos-cli-client`, which the [announcement post](https://blog.openvoiceos.org/posts/2026-07-24-a-terminal-client-for-testing-ovos) describes as unmaintained.

## Why this needs no compose changes

`ovos_cli` already has everything the client wants:

- `network_mode: host` → the messagebus is on `127.0.0.1:8181`
- `${OVOS_CONFIG_FOLDER}` mounted at `~/.config/mycroft` → the config is where it looks, so the command palette's pipeline view is accurate with no `--mycroft-conf` flag
- `ovos_local_state` mounted at `~/.local/state/mycroft` → a log path it already searches
- `depends_on: ovos_messagebus`

So it is one command, no flags:

```shell
docker exec -it ovos_cli ovos-tui
```

`-it` is the one requirement worth documenting: unlike every other service here this is an interactive program and draws nothing without a terminal attached.

## Checks

**Unpinned, and that is deliberate.** Its own floor is wide (`textual>=0.60`) so pip can settle on whatever agrees with the rest of an OVOS install — its requirements file warns that pinning `textual>=8.0` collides with `ovos-utils`' `rich~=13.7` and sends pip into endless backtracking. Rather than assume, I resolved it against all three channels:

| constraints | result |
|---|---|
| `constraints-stable.txt` | resolves |
| `constraints-testing.txt` | resolves |
| `constraints-alpha.txt` | resolves |

alongside `ovos-config` and `ovos-plugin-manager`, no conflict in any of them.

**`COLORTERM=truecolor`.** Tested the client under this image's `TERM=linux`: it works, but renders in 16 colours. With `COLORTERM` set it renders in full colour. I left `TERM=linux` alone since vim and nano live in this image too, and added `COLORTERM` beside it, which those ignore.

## Related

Companion change in [ovos-installer](https://github.com/OpenVoiceOS/ovos-installer), which installs the same client into the OVOS virtualenv so both install methods end up with a terminal client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal-based interaction with OVOS through the `ovos-tui` client.
  * Added full-color terminal rendering support for the OVOS terminal interface.

* **Documentation**
  * Added setup and usage instructions for connecting to OVOS from a terminal, including Docker usage and terminal requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->