### PR TITLE
test: fail the build when an image has no intent engine

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -121,6 +121,49 @@ RUN --mount=type=bind,from=builder,source=/tmp/wheels,target=/tmp/wheels \
  && chown "${USER}:${USER}" -R "/home/${USER}" \
  && rm -f /tmp/requirements.txt
 
+# Fail the build rather than ship an image with no intent engine.
+#
+# padatious reaches the venv only through an ovos-core extra, and which extra carries it changed
+# between the 1.x and 2.x lines. That makes it quietly droppable: an upstream extra rename, or a
+# well-meant "the lgpl extra is obsolete" edit, leaves every build green and every image useless.
+# Asserting here rather than in CI means it runs in each build that already happens - pull request
+# dry runs included, on both architectures and every channel - with no image loading needed.
+#
+# The fann2 half is derived from the padatious that actually landed, not from the channel, so it
+# keeps holding once stable and testing move to a 2.x core.
+RUN <<'PY' python
+from importlib.metadata import PackageNotFoundError, version
+
+
+def installed(name):
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return None
+
+
+padatious = installed("ovos-padatious")
+if padatious is None:
+    raise SystemExit(
+        "no intent engine: ovos-padatious is not installed. It reaches this image only "
+        "through an ovos-core extra, so an extra changed without a replacement requirement."
+    )
+
+fann2 = installed("fann2")
+needs_fann2 = int(padatious.split(".")[0]) < 2
+
+if needs_fann2 and fann2 is None:
+    raise SystemExit(
+        f"ovos-padatious {padatious} is a 1.x release and needs fann2, but fann2 is not "
+        "installed - the build chain was skipped where it was still required."
+    )
+
+if not needs_fann2 and fann2 is not None:
+    print(f"note: ovos-padatious {padatious} does not need fann2, yet fann2 {fann2} is present")
+
+print(f"intent engine ok: ovos-padatious {padatious}, fann2 {fann2 or 'not needed'}")
+PY
+
 USER "$USER"
 WORKDIR "/home/${USER}"
 ENTRYPOINT ["/bin/bash", "/usr/local/bin/entrypoint.sh"]

--- a/skills/skill-base/Dockerfile
+++ b/skills/skill-base/Dockerfile
@@ -73,6 +73,49 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  && apt-get --purge autoremove -y \
  && rm -rf /var/log/{apt,dpkg.log}
 
+# Fail the build rather than ship an image with no intent engine.
+#
+# padatious reaches the venv only through an ovos-core extra, and which extra carries it changed
+# between the 1.x and 2.x lines. That makes it quietly droppable: an upstream extra rename, or a
+# well-meant "the lgpl extra is obsolete" edit, leaves every build green and every image useless.
+# Asserting here rather than in CI means it runs in each build that already happens - pull request
+# dry runs included, on both architectures and every channel - with no image loading needed.
+#
+# The fann2 half is derived from the padatious that actually landed, not from the channel, so it
+# keeps holding once stable and testing move to a 2.x core.
+RUN <<'PY' python
+from importlib.metadata import PackageNotFoundError, version
+
+
+def installed(name):
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return None
+
+
+padatious = installed("ovos-padatious")
+if padatious is None:
+    raise SystemExit(
+        "no intent engine: ovos-padatious is not installed. It reaches this image only "
+        "through an ovos-core extra, so an extra changed without a replacement requirement."
+    )
+
+fann2 = installed("fann2")
+needs_fann2 = int(padatious.split(".")[0]) < 2
+
+if needs_fann2 and fann2 is None:
+    raise SystemExit(
+        f"ovos-padatious {padatious} is a 1.x release and needs fann2, but fann2 is not "
+        "installed - the build chain was skipped where it was still required."
+    )
+
+if not needs_fann2 and fann2 is not None:
+    print(f"note: ovos-padatious {padatious} does not need fann2, yet fann2 {fann2} is present")
+
+print(f"intent engine ok: ovos-padatious {padatious}, fann2 {fann2 or 'not needed'}")
+PY
+
 USER "$USER"
 
 ENTRYPOINT ["/usr/local/bin/skill-entrypoint.sh"]


### PR DESCRIPTION
Follow-up to #173. That PR made the fann2 build chain conditional; this one makes it impossible to ship an image that quietly lost its intent engine.

## Why

padatious reaches these images only through an ovos-core extra, and which extra carries it changed between the 1.x and 2.x lines. That makes it quietly droppable — an upstream extra rename, or a well-meant "the `lgpl` extra is obsolete" edit, leaves every build green and every image useless.

That is not hypothetical: [ovos-installer#587](https://github.com/OpenVoiceOS/ovos-installer/pull/587) was exactly that change, and nothing in this repo would have caught it. On the installer side it surfaced only because an Arch job happens to `import fann2`.

## Where the check lives, and why not in CI

I first planned this as a step in the `verify` job plus `--load` in the dry-run path. That turned out to be the worse design: `verify` runs only on push, `--load` puts every built image into a runner's daemon on ~14GB of free disk, and it all reshapes the pipeline to test something the build already knows.

So the assertion is the last `RUN` of the `core` and `skill-base` builds — the only two images that install ovos-core; every other service builds from sound-base. It therefore runs in each build that already happens: **pull request dry runs, both architectures, all three channels**, with nothing loaded and no workflow change.

The fann2 half is derived from the padatious that actually landed, not from the channel, so it keeps holding once stable and testing move to a 2.x core. A 2.x padatious that still has fann2 alongside only prints a note — a rebuilt layer can legitimately carry it.

## Verification

Passing on every real configuration:

```
core       alpha    intent engine ok: ovos-padatious 2.0.16a1, fann2 not needed
core       testing  intent engine ok: ovos-padatious 1.4.3, fann2 1.0.7
skill-base alpha    intent engine ok: ovos-padatious 2.0.16a1, fann2 not needed
skill-base testing  intent engine ok: ovos-padatious 1.4.3, fann2 1.0.7
```

Both failure modes negative-tested by building on top of a good image, with the assertion extracted from the Dockerfile itself so the test cannot drift from what ships:

```
padatious removed          -> no intent engine: ovos-padatious is not installed...   exit code: 1
padatious 1.x, no fann2    -> ovos-padatious 1.4.3 is a 1.x release and needs fann2...  exit code: 1
```

## Cost

One `RUN` with no filesystem writes, so it adds an empty layer and a fraction of a second per build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)