### PR TITLE
fix(ci): publish from the last commit actually published

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -31,8 +31,21 @@ jobs:
       - id: sel
         env:
           BEFORE: ${{ github.event.before }}
+          GH_TOKEN: ${{ github.token }}
           HEAD: ${{ github.sha }}
         run: |
+          # Diff from the last commit this workflow actually published, not from this push's own
+          # parent. Only one run may sit pending in a concurrency group, so when several merges land
+          # minutes apart the middle ones are cancelled - and the next push's github.event.before is
+          # the cancelled push's head, so whatever that push would have rebuilt is skipped for good
+          # rather than retried. That is not hypothetical: the sibling repository shipped a
+          # base/Dockerfile change that stayed unpublished for two days for exactly this reason.
+          last=$(gh run list --workflow on-push.yml --branch "$GITHUB_REF_NAME" \
+                   --status success --limit 1 --json headSha -q '.[0].headSha' 2>/dev/null || true)
+          if [ -n "$last" ] && git cat-file -e "$last" 2> /dev/null; then
+            echo "diffing from the last successful publish: $last"
+            BEFORE="$last"
+          fi
           if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BEFORE" 2> /dev/null; then
             echo "no usable base commit -> building everything"
             files="docker-bake.hcl"


### PR DESCRIPTION
A publish that gets cancelled is never retried, and nothing reports it.

## What happens

The selector diffs `github.event.before..github.sha` — only the commits of the push that triggered it. A concurrency group holds just **one pending run**, so when several merges land minutes apart the middle ones are cancelled. The next push's `github.event.before` is then the *cancelled* push's head, so no later diff ever spans the skipped commits again.

The work is not delayed. It is dropped, silently, with every run green.

## It already happened

In JarbasHiveMind/hivemind-docker on 2026-09-09, three merges landed within 30 minutes:

```
16:02  271aff80  cancelled
16:05  bb56e607  cancelled     <- touched base/Dockerfile
16:30  3601ef37  success       <- diffed from bb56e607, so never saw it
```

`base/` is the root of that bake graph, so `bb56e607` should have rebuilt every image. Two days later `hivemind-cli`, `hivemind-listener` and `hivemind-satellite` at `:testing` were still built from `6087d744`, a commit older than that change — while the compose files an install runs came from a tag that included it.

It surfaced only because a new cross-repo image-coherence check went looking ([ovos-installer#603](https://github.com/OpenVoiceOS/ovos-installer/pull/603)); no CI in either repository was unhappy.

## The change

Selection starts from the last commit this workflow published **successfully**, falling back to `github.event.before` when that cannot be resolved (first run on a branch, unreachable commit, `gh` unavailable). A cancelled or failed publish is therefore picked up by the next one.

This repository has the identical selector and concurrency group, so it has the same latent gap even though the loss happened in the sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection for push-triggered publishing by comparing updates with the most recently successful publish, helping ensure all affected targets are identified correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->