### PR TITLE
fix(ci): say so when the publish base cannot be looked up

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -20,6 +20,15 @@ jobs:
   select:
     name: Affected targets
     runs-on: ubuntu-24.04
+    # This job reads this workflow's own run history, which the workflow-level block does not
+    # grant - and a job-level block replaces it, so the checkout's contents: read is restated
+    # while the write access this job never needed is dropped. The lookup happens to succeed
+    # today because the repository is public and its Actions API is readable anonymously; that
+    # is a property of the repository, not of the permissions, and it would stop being true the
+    # day the repository turned private.
+    permissions:
+      actions: read
+      contents: read
     outputs:
       targets: ${{ steps.sel.outputs.targets }}
       count: ${{ steps.sel.outputs.count }}
@@ -40,11 +49,30 @@ jobs:
           # the cancelled push's head, so whatever that push would have rebuilt is skipped for good
           # rather than retried. That is not hypothetical: the sibling repository shipped a
           # base/Dockerfile change that stayed unpublished for two days for exactly this reason.
-          last=$(gh run list --workflow on-push.yml --branch "$GITHUB_REF_NAME" \
-                   --status success --limit 1 --json headSha -q '.[0].headSha' 2>/dev/null || true)
-          if [ -n "$last" ] && git cat-file -e "$last" 2> /dev/null; then
-            echo "diffing from the last successful publish: $last"
-            BEFORE="$last"
+          # "There is no previous successful publish" and "we could not find out" are different
+          # answers and must not share a branch. The first is normal on a new branch. The second
+          # used to be swallowed by `|| true`, which fell back to this push's parent - the exact
+          # base that drops a cancelled run's work - while the log said nothing and the job
+          # stayed green. Failing the lookup now builds everything: wasteful, visible, and it
+          # never drops a publish.
+          if last=$(gh run list --workflow on-push.yml --branch "$GITHUB_REF_NAME" \
+                      --status success --limit 1 --json headSha -q '.[0].headSha' 2>/dev/null); then
+            if [ -z "$last" ]; then
+              echo "no previous successful publish on this branch; diffing from this push's parent"
+            elif git cat-file -e "$last" 2> /dev/null; then
+              echo "diffing from the last successful publish: $last"
+              BEFORE="$last"
+            else
+              # A third answer, and not the same as having none: a publish happened and this
+              # clone cannot see the commit, which a rewritten branch produces. Diffing from the
+              # push parent here would skip whatever that publish did not cover, which is the
+              # defect this whole step exists to avoid.
+              echo "::warning::the last successful publish ($last) is not in this clone, so what it covered cannot be determined; building every target rather than diffing from this push's parent"
+              BEFORE=""
+            fi
+          else
+            echo "::warning::could not read this workflow's run history; building every target rather than diffing from this push's parent, which drops work when a run is cancelled"
+            BEFORE=""
           fi
           if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BEFORE" 2> /dev/null; then
             echo "no usable base commit -> building everything"


### PR DESCRIPTION
Follows an unresolved review comment on #181, which turns out to be right.

The `select` job asks this workflow's own run history for the last commit it actually published, so a cancelled run's work is retried rather than skipped for good. **It never had permission to ask.** The workflow-level `permissions:` block grants `contents`, `packages` and `id-token`, and naming any permission sets every other one to `none` — so `actions` is `none` for this job.

It succeeds regardless, because this repository is public and its Actions API is readable anonymously. I verified that against the real run from #179:

```
diffing from the last successful publish: 5373a566df267ad1eba6d237b5f994086d9c19e7
```

So nothing is broken today. But that is a property of the repository, not of the permissions. The day this repository turns private, `|| true` swallows the failure, the diff silently reverts to `github.event.before`, and the publish that gets dropped when a run is cancelled starts being dropped again — with every run still green. That is the same shape as the defect #181 was written to fix.

## Changes

**`actions: read` on the job.** A job-level block replaces the workflow-level one, so this also drops the `contents: write` / `packages: write` / `id-token: write` that the select job never needed.

**A failed lookup is no longer the same answer as an empty one.** Three outcomes now, where there were two:

| lookup | before | now |
|---|---|---|
| returns a sha | diff from it | unchanged |
| succeeds, empty (new branch) | diff from push parent | diff from push parent, and says so |
| **fails** | **diff from push parent, silently** | build every target, with a `::warning::` |

Building everything is wasteful and visible, which is the right way round: it cannot drop a publish.

## Verification

All three paths exercised against a throwaway repository with a stubbed `gh`, under `bash -e` as the runner invokes it:

```
1. lookup returns a sha    -> diffing from the last successful publish: 15a2952
2. lookup succeeds, empty  -> no previous successful publish on this branch; diffing from this push's parent
3. lookup FAILS            -> ::warning:: ... / RESULT: building everything
```

The same fix applies to hivemind-docker, whose workflow is identical — filed alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publish history handling when run history cannot be retrieved.
  * Ensures all targets are rebuilt instead of incorrectly using the current push’s parent commit after interrupted or cancelled runs.
* **Chores**
  * Updated workflow permissions to allow required read-only access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->