### PR TITLE
docs: name the GHCR mirror path a pull actually resolves

### DIFF
--- a/docs/getting-started/docker/build.md
+++ b/docs/getting-started/docker/build.md
@@ -64,7 +64,7 @@ Defaults come from `scripts/bake.sh` and `docker-bake.hcl`:
 | `UV_PRERELEASE`   | `allow`                       | `uv pip` prerelease policy; use `if-necessary-or-explicit` for `testing`/`stable` (CI does) |
 | `CACHE_REPO`      | `ghcr.io/openvoiceos/ovos-docker-cache` | Registry build cache, read anonymously                |
 | `CACHE_TO`        | _(empty)_                     | `max` also exports the build cache (needs GHCR write access; CI does this) |
-| `MIRROR_REGISTRY` | _(empty)_                     | Second registry every image is also pushed to (CI: `ghcr.io/openvoiceos`); the pipeline reads manifests, labels and SBOMs from it |
+| `MIRROR_REGISTRY` | _(empty)_                     | Second registry every image is also pushed to (CI: `ghcr.io/openvoiceos/ovos-docker`); the pipeline reads manifests, labels and SBOMs from it |
 | `PLATFORMS`       | `linux/amd64,linux/arm64`      | Platforms to build                                            |
 | `TARGETS`         | `default`                     | Bake targets/groups                                           |
 | `PUSH`            | `true`                        | Push images to the registry                                   |

--- a/docs/getting-started/docker/composition.md
+++ b/docs/getting-started/docker/composition.md
@@ -7,6 +7,17 @@ The easiest and quickest way to deploy Open Voice OS containers is to use a [com
     Compose files live under `compose/` in the repository. Run commands from
     that directory or pass `--env-file compose/.env` and `--file compose/<name>`.
 
+!!! warning "Compose files and images move at different speeds"
+
+    A compose file is whatever your checkout holds, while `VERSION` selects a
+    [channel tag](./images.md#tags) that keeps moving. `docker compose pull`
+    therefore fetches newer images against the compose file you already have,
+    and a service gains a mounted path or an environment variable in `compose/`
+    before the image expecting it reaches you — or after, if your checkout is
+    old. Update the checkout and the images together: pull the repository at a
+    release tag, then `docker compose pull`, then recreate the stack. Pinning
+    `VERSION` to a digest holds an image still if you need a fixed target.
+
 ## Composition files
 
 Composition files provide an easy way to provision the stack _(services and volumes)_ with the required options and configuration for each of the services. The names below reflect the bundle layout shipped in `compose/`.

--- a/docs/getting-started/docker/images.md
+++ b/docs/getting-started/docker/images.md
@@ -4,8 +4,9 @@
 
     The compose bundles in `compose/` reference images hosted on Docker Hub
     under `docker.io/smartgic`. The same images, with the same tags and
-    digests, are also published to `ghcr.io/openvoiceos` (for example
-    `ghcr.io/openvoiceos/ovos-core:alpha`), a mirror without pull-rate limits;
+    digests, are also published to `ghcr.io/openvoiceos/ovos-docker` (for
+    example `ghcr.io/openvoiceos/ovos-docker/ovos-core:alpha`), a mirror
+    without pull-rate limits;
     point the `image:` references of your compose files there if Docker Hub
     rate-limits you. Buildx Bake defaults to `docker.io/smartgic`; if you
     publish to a different registry, update the `image:` references in your
@@ -76,7 +77,8 @@ a virtual environment and a pinned [uv](https://github.com/astral-sh/uv));
 services needing sound add `ovos-sound-base`, skills add `ovos-skill-base`.
 Every channel tag is a multi-architecture manifest list (`amd64` + `arm64`)
 carrying an SBOM and SLSA provenance attestation, signed with cosign, published
-to both `docker.io/smartgic` and `ghcr.io/openvoiceos` with identical digests,
+to both `docker.io/smartgic` and `ghcr.io/openvoiceos/ovos-docker` with
+identical digests,
 and labelled with:
 
 | Label                                 | Content                                                                      |


### PR DESCRIPTION
The mirror is `ghcr.io/openvoiceos/ovos-docker`, not `ghcr.io/openvoiceos`. Every path these pages offered dropped the repository segment, so a reader following the example to escape a Docker Hub rate limit got a 404:

```
ghcr.io/openvoiceos/ovos-core:testing             -> HTTP 404   (what the docs say)
ghcr.io/openvoiceos/ovos-docker/ovos-core:testing -> HTTP 200   (what is published)
```

The segment was never optional: `build-images.yml` defaults `mirror_registry` to `ghcr.io/openvoiceos/ovos-docker`, and `docker-bake.hcl` forms each mirror tag as `${MIRROR_REGISTRY}/${image}:${TAG}`. The build page named the same short path when describing what CI sets. `CACHE_REPO` was already right and is untouched.

Composition also gains the consequence of the two halves moving independently. A compose file is whatever the checkout holds, while `VERSION` selects a channel tag that keeps moving — so `docker compose pull` fetches newer images against the compose file already on disk, and a service gains a mount or an environment variable in `compose/` either before or after the image expecting it, depending on how old the checkout is. The note says to update both together, and that pinning to a digest holds one still.

Verified against the live registry (the HTTP codes above are real anonymous pulls of the v2 manifest API), and `mkdocs build --strict` passes with the git-committers token supplied the way the deploy workflow supplies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)