### PR TITLE
docs: say that compose/ is a published interface, and what on-push diffs from

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ All Python images share `ovos-base` (Debian slim, Python 3.13, a virtual environ
 pinned [uv](https://github.com/astral-sh/uv)). Each image has a `HEALTHCHECK`, an SBOM, a
 provenance attestation, and a cosign signature.
 
+The compose files under `compose/` are consumed by other projects, not only by people: the
+[OVOS installer](https://github.com/OpenVoiceOS/ovos-installer) clones this repository at a
+release tag and runs them. The compose file names, the container names, the environment
+variables the compose reads and the images it pulls are therefore a published interface, and
+`contract.yml` declares all four. Run `scripts/contract.py --write` after editing `compose/`;
+CI fails when the declaration and the compose files disagree.
+
 ## Talking to OVOS from a terminal
 
 The `ovos-cli` image ships [ovos-tui-client](https://github.com/andlo/ovos-tui-client),
@@ -128,7 +135,7 @@ multi-arch manifest lists. The workflows are in `.github/workflows/`:
 
 | Workflow | Trigger | What it builds |
 |---|---|---|
-| `on-push.yml` | A commit on `dev` | The targets whose build context changed, plus the targets built on top of them, for `alpha`, `testing`, and `stable` |
+| `on-push.yml` | A commit on `dev` | The targets whose build context changed since the last commit this workflow published, plus the targets built on top of them, for `alpha`, `testing`, and `stable` |
 | `on-constraints.yml` | A `repository_dispatch` from ovos-releases, an hourly poll, or a manual run | For each channel, the images that contain a package whose `constraints-<channel>.txt` line changed since the last build |
 | `pull-request.yml` | A pull request | The affected targets, for both architectures, without a push |
 | `scheduled-rebuild.yml` | Once a week | Every image of a channel |

--- a/README_MACOS.md
+++ b/README_MACOS.md
@@ -124,7 +124,7 @@ PulseAudio may use a different audio output (sink) than the one actually used by
 
 ## How to use these images
 
-Please refer to [this section](README.md#how-to-use-these-images) of the documentation.
+Please refer to [this section](README.md#run-images) of the documentation.
 
 ## Thanks
 

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -69,7 +69,7 @@ Time per period = 3.278807
 
 ## How to use these images
 
-Please refer to [this section](README.md#how-to-use-these-images) of the documentation.
+Please refer to [this section](README.md#run-images) of the documentation.
 
 ## Thanks
 


### PR DESCRIPTION
Three corrections to the READMEs on `dev`, found while checking whether the documentation kept up with the cross-repository contract work.

**`compose/` is consumed by another project and nothing said so.** The [OVOS installer](https://github.com/OpenVoiceOS/ovos-installer) clones this repository at a release tag and runs these compose files, which makes the compose file names, the container names it execs into, the environment variables the compose reads and the images it pulls a published interface. `contract.yml` declares all four so the dependency cannot drift unnoticed — but a contributor editing `compose/` had no way to learn any of that from the README, or that `scripts/contract.py --write` has to be rerun afterwards.

**The automation table described the wrong diff base.** It said `on-push.yml` builds what changed on a commit to `dev`. It builds what changed since the last commit the workflow *actually published* — not the same base whenever a run was cancelled, which is exactly when the difference matters, because that work would otherwise be skipped for good rather than retried (#181, #182).

**Both platform READMEs pointed at a heading that does not exist.** `README.md#how-to-use-these-images` has had no such heading for years; the section a reader wants is `#run-images`. Every remaining relative anchor into README.md was checked and resolves.

`scripts/contract.py` passes on this branch: `contract.yml matches compose/ (10 files, 49 services, 29 variables)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Compose files are a published interface used by the OVOS installer and validated in continuous integration.
  * Updated automation documentation to explain how changed build contexts determine published targets.
  * Corrected macOS and Windows documentation links to point to the current image-running instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->